### PR TITLE
Switch to aspect rules_py

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.
 ```
 - externla/com_google_protobuf warning directory does not exist
 
+
+## References
+
+### Bazel
+
+- [query](https://bazel.build/query/language)
+
+#### Notes
+- bzlmod is where things will be moving to better share dependency information and use a central regirstry: https://bazel.build/external/migration

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,26 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "aspect_rules_py",
+    sha256 = "50b4b43491cdfc13238c29cb159b7ccacf0a1e54bd27b65ff2d5fac69af4d46f",
+    strip_prefix = "rules_py-0.4.0",
+    url = "https://github.com/aspect-build/rules_py/releases/download/v0.4.0/rules_py-v0.4.0.tar.gz",
+)
+# Fetches the rules_py dependencies.
+# (must come before aspect's gcc toolchain dependencies)
+load("@aspect_rules_py//py:repositories.bzl", "rules_py_dependencies")
+rules_py_dependencies()
+
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+
+# We install the rules_python dependencies using the function below.
+py_repositories()
+python_register_toolchains(
+    name = "python39",
+    python_version = "3.9",
+)
+
+http_archive(
     name = "aspect_gcc_toolchain",
     sha256 = "3341394b1376fb96a87ac3ca01c582f7f18e7dc5e16e8cf40880a31dd7ac0e1e",
     strip_prefix = "gcc-toolchain-0.4.2",
@@ -8,34 +28,15 @@ http_archive(
         "https://github.com/aspect-build/gcc-toolchain/archive/refs/tags/0.4.2.tar.gz",
     ],
 )
-
 load("@aspect_gcc_toolchain//toolchain:repositories.bzl", "gcc_toolchain_dependencies")
-
 gcc_toolchain_dependencies()
 
 load("@aspect_gcc_toolchain//toolchain:defs.bzl", "gcc_register_toolchain", "ARCHS")
-
 gcc_register_toolchain(
     name = "gcc_toolchain_x86_64",
     target_arch = ARCHS.x86_64,
 )
 
-http_archive(
-    name = "rules_python",
-    sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b",
-    strip_prefix = "rules_python-0.26.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.26.0/rules_python-0.26.0.tar.gz",
-)
-
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
-
-# We install the rules_python dependencies using the function below.
-py_repositories()
-
-python_register_toolchains(
-    name = "python39",
-    python_version = "3.9",
-)
 
 # http_archive(
 #     name = "rules_python_gazelle_plugin",

--- a/experiments/proto/hello/BUILD
+++ b/experiments/proto/hello/BUILD
@@ -1,3 +1,4 @@
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
@@ -29,3 +30,7 @@ py_test(
   ],
 )
 
+py_binary(
+  name = "main",
+  srcs = ["main.py"],
+)

--- a/experiments/proto/hello/main.py
+++ b/experiments/proto/hello/main.py
@@ -1,0 +1,6 @@
+def main():
+    print('Hello World')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Generate a venv for a py_binary by appending `.venv` to it, it'll then be found in the home directory, eg)

```
bazel run //experiments/proto/hello:main.venv
```
Results in a venv at `.main.venv`

We could query for all py_ targets via `bazel query('kind("py_.*", //...)'` and use that to generate an all-inclusive venv for development, including an ipython shell. I wonder what the best way to keep that up to date is?