### PR TITLE
Add/Run buildifier, Update rules_python, Install Tools, Setup udev rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ bazel-bin
 bazel-out
 bazel-testlogs
 bazel-toolbox
+
+# VS Code
+.vscode/arduino.json

--- a/BUILD
+++ b/BUILD
@@ -103,7 +103,6 @@ gazelle(
 # TODO: Figure out a way to not need these
 # gazelle:resolve py examples.basic.hello_pb2 //examples/basic:hello_py_library
 
-# XYZ
 package(default_visibility = ["//visibility:private"])
 
 # Run as:

--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,7 @@
 # The `load` statement imports the symbol for the rule, in the defined
 # ruleset. When the symbol is loaded you can use the rule.
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@pip//:requirements.bzl", "all_whl_requirements")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
@@ -103,3 +104,7 @@ gazelle(
 # gazelle:resolve py examples.basic.hello_pb2 //examples/basic:hello_py_library
 
 package(default_visibility = ["//visibility:private"])
+
+buildifier(
+    name = "buildifier",
+)

--- a/BUILD
+++ b/BUILD
@@ -103,8 +103,13 @@ gazelle(
 # TODO: Figure out a way to not need these
 # gazelle:resolve py examples.basic.hello_pb2 //examples/basic:hello_py_library
 
+# XYZ
 package(default_visibility = ["//visibility:private"])
 
+# Run as:
+# bazel run //:buildifier -- <args>
 buildifier(
     name = "buildifier",
 )
+# Run buildozer as:
+# bazel run --run_under="cd $PWD && " @com_github_bazelbuild_buildtools//buildozer --  <args>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -183,7 +183,6 @@ python_register_toolchains(
 )
 
 load("@python39//:defs.bzl", "interpreter")
-
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 # This macro wraps the `pip_repository` rule that invokes `pip`, with `incremental` set.
@@ -192,8 +191,6 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 # You can instead check this `requirements.bzl` file into your repo.
 pip_parse(
     name = "pip",
-    # Set the location of the lock file.
-    requirements_lock = "//:requirements_lock.txt",
     # (Optional) You can provide a python_interpreter (path) or a python_interpreter_target (a Bazel target, that
     # acts as an executable). The latter can be anything that could be used as Python interpreter. E.g.:
     # 1. Python interpreter that you compile in the build file.
@@ -201,6 +198,8 @@ pip_parse(
     # 3. Wrapper script, like in the autodetecting python toolchain.
     # Here, we use the interpreter constant that resolves to the host interpreter from the default Python toolchain.
     python_interpreter_target = interpreter,
+    # Set the location of the lock file.
+    requirements_lock = "//:requirements_lock.txt",
 )
 
 # Load the install_deps macro.
@@ -240,3 +239,12 @@ gazelle_protobuf_extension_go_deps()
 load("@build_stack_rules_proto//deps:protobuf_core_deps.bzl", "protobuf_core_deps")
 
 protobuf_core_deps()
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    sha256 = "ae34c344514e08c23e90da0e2d6cb700fcd28e80c02e23e4d5715dddcb42f7b3",
+    strip_prefix = "buildtools-4.2.2",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.2.tar.gz",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -167,7 +167,6 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.29.0/rules_python-0.29.0.tar.gz",
 )
 
-
 # Next we load the setup and toolchain from rules_python.
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,12 +7,11 @@ workspace(name = "mchristen")
 # file.  When the symbol is loaded you can use the rule.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# TODO: Install the newest version once #1664 gets released to fix py_binary issues
 http_archive(
     name = "rules_python",
-    sha256 = "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
-    strip_prefix = "rules_python-0.28.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz",
+    sha256 = "d71d2c67e0bce986e1c5a7731b4693226867c45bfe0b7c5e0067228a536fc580",
+    strip_prefix = "rules_python-0.29.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.29.0/rules_python-0.29.0.tar.gz",
 )
 
 http_archive(
@@ -163,10 +162,11 @@ gazelle_dependencies()
 
 http_archive(
     name = "rules_python_gazelle_plugin",
-    sha256 = "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
-    strip_prefix = "rules_python-0.28.0/gazelle",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz",
+    sha256 = "d71d2c67e0bce986e1c5a7731b4693226867c45bfe0b7c5e0067228a536fc580",
+    strip_prefix = "rules_python-0.29.0/gazelle",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.29.0/rules_python-0.29.0.tar.gz",
 )
+
 
 # Next we load the setup and toolchain from rules_python.
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")

--- a/ansible_playbooks/dev_setup.yaml
+++ b/ansible_playbooks/dev_setup.yaml
@@ -4,7 +4,7 @@
 #   - Installing core packages
 #   - Bootstrapping shared config (git directory that sets up links)
 # Thoughts?
-# - 
+# -
 #  remote_user: "{{ lookup('env', 'USER') }}"
 #  become_flags: "--preserve-env=SSH_AUTH_SOCK"
 #  vars:
@@ -39,7 +39,7 @@
 #     - name: Gather the package facts
 #       ansible.builtin.package_facts:
 #         manager: auto
-#     
+#
 #     - name: Print the package facts
 #       ansible.builtin.debug:
 #         var: ansible_facts.packages
@@ -48,6 +48,17 @@
   tasks:
     - become: true
       block:
+        - name: Configure apt for syncthing
+          block:
+            - name: syncthing |no apt key
+              ansible.builtin.get_url:
+                url: https://syncthing.net/release-key.gpg
+                dest: /etc/apt/keyrings/syncthing-archive-keyring.gpg
+            - name: syncthing | apt source
+              ansible.builtin.apt_repository:
+                repo: "deb [signed-by=/etc/apt/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing stable"
+                state: present
+
         - name: Install Packages
           ansible.builtin.package:
             # TODO: versions?
@@ -71,6 +82,8 @@
               - ranger
               # Searching
               - silversearcher-ag
+              # Sharing notes
+              - syncthing
 - name: Configure Dynamic DNS
   hosts: all
   tasks:

--- a/ansible_playbooks/dev_setup.yaml
+++ b/ansible_playbooks/dev_setup.yaml
@@ -43,6 +43,9 @@
 #     - name: Print the package facts
 #       ansible.builtin.debug:
 #         var: ansible_facts.packages
+# TODO:
+# - register users with dialout
+# - passwordless sudo?
 - name: Setup a new machine for a developer
   hosts: all
   tasks:
@@ -58,7 +61,9 @@
               ansible.builtin.apt_repository:
                 repo: "deb [signed-by=/etc/apt/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing stable"
                 state: present
-
+        - name: Configure kicad apt repositories
+          ansible.builtin.apt_repository:
+            repo: "ppa:kicad/kicad-7.0-releases"
         - name: Install Packages
           ansible.builtin.package:
             # TODO: versions?
@@ -74,7 +79,9 @@
               - build-essential
               # java
               # TODO: same deal as build-essential
-              - openjdk-19-jre-headless
+              # - openjdk-19-jre-headless
+              # Switched from ^ to have gui
+              - openjdk-19-jre
               # For development purposes
               - python3.10-venv
               # Directory Viewing Utilities
@@ -82,8 +89,51 @@
               - ranger
               # Searching
               - silversearcher-ag
+              # AppImage Support
+              - fuse
+              - libfuse2
               # Sharing notes
+              # TODO: COnfigure as a service
               - syncthing
+              # XXX: waveforms is crashing when attempting to start
+              # NOTE: Can start fine from application launcher :shrug:
+              # TODO: digilent-agent isn't working though / no launcher
+              - libqt5serialport5-dev
+              - xterm
+              - libxcb-xinput-dev
+              # - qt5-default  # XXX: This should fix, but is unavailable
+              - arduino
+              - blender
+              - kicad
+              # XXX: None of this worked, uninstall it
+              # - xcb
+              # - qtbase5-dev
+              # - qtchooser
+              # - qt5-qmake
+              # - qtbase5-dev-tools
+              # - name: Uninstall Packages
+              #   ansible.builtin.package:
+              #     name:
+              #       - xcb
+              #       - qtbase5-dev
+              #       - qtchooser
+              #       - qtbase5-dev-tools
+              #     state: absent
+              # https://code.visualstudio.com/download#
+              #
+        # TODO: Improve speed of these (seems to re-download each time)
+        # - name: Install Digilent Adept for Waveforms
+        #   ansible.builtin.apt:
+        #     deb: https://digilent.s3.us-west-2.amazonaws.com/Software/Adept2+Runtime/2.27.9/digilent.adept.runtime_2.27.9-amd64.deb
+        # - name: Install Waveforms
+        #   ansible.builtin.apt:
+        #     deb: https://digilent.s3.us-west-2.amazonaws.com/Software/Waveforms2015/3.21.3/digilent.waveforms_3.21.3_amd64.deb
+        # - name: Install Waveforms Agent
+        #   ansible.builtin.apt:
+        #     deb: https://s3-us-west-2.amazonaws.com/digilent/Software/Digilent+Agent/1.0.1/digilent-agent_1.0.1-1_amd64.deb
+        # - name: Install vscode
+        #   ansible.builtin.apt:
+        #     deb: https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64
 - name: Configure Dynamic DNS
   hosts: all
   tasks:
@@ -131,5 +181,20 @@
           with_file:
             - ssh_keys/mchristen_work
             - ssh_keys/mchristen_phone
-
-# TODO: usb setup? or just a script?
+# XXX: This doesn't seem to properly be setting us up
+# Instead, we are simply linked to input/event..
+- name: Configure udev rules
+  hosts: all
+  tasks:
+    - become: true
+      block:
+        - name: "Set dev-hardware rules"
+          ansible.builtin.copy:
+            src: udev/99-dev-hardware.rules
+            dest: /etc/udev/rules.d/99-dev-hardware.rules
+            mode: 0644
+          notify: Reload udev
+          # TODO: Do this, iterating over all the files
+  handlers:
+    - name: Reload udev
+      include_tasks: tasks/reload_udev.yaml

--- a/ansible_playbooks/tasks/reload_udev.yaml
+++ b/ansible_playbooks/tasks/reload_udev.yaml
@@ -1,0 +1,13 @@
+---
+- name: Reload udev
+  become: true
+  block:
+    # - name: Debug
+    #   ansible.builtin.debug:
+    #     msg: Reloading udev
+    - name: Reload
+      ansible.builtin.command:
+        cmd: "udevadm control --reload-rules"
+    - name: Trigger
+      ansible.builtin.command:
+        cmd: "udevadm trigger"

--- a/ansible_playbooks/udev/99-dev-hardware.rules
+++ b/ansible_playbooks/udev/99-dev-hardware.rules
@@ -1,0 +1,84 @@
+# lsusb output
+# Bus 001 Device 025: ID <vendor>:<product> STMicroelectronics ST-LINK/V2.1
+# [How to Interpret lsusb](https://dassencio.org/21)
+#
+# usb-devices gives even more information and seems to be even better, spells
+# out things and gives SerialNumber.
+#
+# udevadm info --name=/dev/ttyX | grep ID_SERIAL_SHORT
+#
+# Reload:
+# sudo udevadm control --reload-rules && sudo udevadm trigger
+#
+# NOTE: Largely dependent on manufacturer for unique SerialNumbers
+#
+# udev rules for multi-channel FTDIs.
+# $env{.LOCAL_PORT_NUM}"
+# SUBSYSTEMS=="usb", ENV{.LOCAL_PORT_NUM}="$attr{bInterfaceNumber}"
+# https://unix.stackexchange.com/questions/86728/udev-rule-to-match-multiple-node-usb-device
+#
+# TODO: When should MODE not be 0666
+
+# 1BitSquared ICEBreaker FPGA
+SUBSYSTEM=="tty" \
+, ATTRS{idVendor}=="0403" \
+, ATTRS{idProduct}=="6010" \
+, ATTRS{serial}=="ibmJq5vb" \
+, MODE="0666" \
+, SYMLINK+="ttyUSB.icebreaker-fpga-0"
+
+# STM32F3 Discovery STLink
+SUBSYSTEM=="tty" \
+, ATTRS{idVendor}=="0483" \
+, ATTRS{idProduct}=="374b" \
+, ATTRS{serial}=="066BFF575285514867193424" \
+, MODE="0666" \
+, SYMLINK+="ttyUSB.stm32f3-discovery-0"
+# TODO: Not working
+# # Joystick for ^
+# SUBSYSTEM=="tty" \
+# , ATTRS{idVendor}=="0483" \
+# , ATTRS{idProduct}=="5710" \
+# , ATTRS{serial}=="066BFF575285514867193424" \
+# , MODE="0666" \
+# , SYMLINK+="ttyUSB.stm32f3-discovery-0-user-input"
+
+# Lattice ICE FPGA Interface Cable
+# There's also 2 ports?
+SUBSYSTEM=="tty" \
+, ATTRS{idVendor}=="0403" \
+, ATTRS{idProduct}=="6010" \
+, ATTRS{serial}=="ibmJq5vb" \
+, MODE="0666" \
+, SYMLINK+="ttyUSB.lattice-icestick-fpga-0"
+
+# Get registered differently / waveforms can still detect them regardless
+# # Analog Discovery V1: 210244580803
+# SUBSYSTEM=="tty" \
+# , ATTRS{idVendor}=="0403" \
+# , ATTRS{idProduct}=="6014" \
+# , ATTRS{serial}=="210244580803" \
+# , MODE="0666" \
+# , SYMLINK+="ttyUSB.analog-discovery-v1-0"
+#
+# # Analog Discovery V3: 210415BB063E
+# SUBSYSTEM=="tty" \
+# , ATTRS{idVendor}=="1443" \
+# , ATTRS{idProduct}=="7003" \
+# , ATTRS{serial}=="066BFF575285514867193424" \
+# , MODE="0666" \
+# , SYMLINK+="ttyUSB.analog-discovery-v3-0"
+
+SUBSYSTEM=="tty" \
+, ATTRS{idVendor}=="2341" \
+, ATTRS{idProduct}=="0042" \
+, ATTRS{serial}=="74133353437351206081" \
+, MODE="0666" \
+, SYMLINK+="ttyUSB.arduino-mega-2560-0"
+
+SUBSYSTEM=="tty" \
+, ATTRS{idVendor}=="0403" \
+, ATTRS{idProduct}=="6001" \
+, ATTRS{serial}=="A700dZjI" \
+, MODE="0666" \
+, SYMLINK+="ttyUSB.arduino-duemilanove-0"

--- a/docs/bringup.md
+++ b/docs/bringup.md
@@ -6,3 +6,8 @@
 2023-12-27, Wednesday:
 
 - lots of misceallenous things
+
+2023-01-29, Monday:
+
+- I've been installing more packages, like KiCad, etc.
+  - neat set of tools: https://github.com/devbisme/kicad-3rd-party-tools

--- a/examples/basic/BUILD
+++ b/examples/basic/BUILD
@@ -1,7 +1,7 @@
 load("@build_stack_rules_proto//rules/py:proto_py_library.bzl", "proto_py_library")
 load("@build_stack_rules_proto//rules/cc:proto_cc_library.bzl", "proto_cc_library")
 load("@build_stack_rules_proto//rules:proto_compile.bzl", "proto_compile")
-load("@aspect_rules_py//py:defs.bzl", "py_library", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
@@ -82,7 +82,7 @@ py_test(
     ],
 )
 
-py_library(
+py_binary(
     name = "main",
     srcs = ["main.py"],
     visibility = ["//:__subpackages__"],

--- a/examples/basic/main.py
+++ b/examples/basic/main.py
@@ -2,6 +2,5 @@ def main():
     print('Hello World')
 
 
-# TODO(https://github.com/bazelbuild/rules_python/pull/1664) fixes this, add with next release
-# if __name__ == '__main__':
-#     main()
+if __name__ == '__main__':
+    main()

--- a/mchristen/parsing_scripts/BUILD
+++ b/mchristen/parsing_scripts/BUILD
@@ -1,32 +1,15 @@
-load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library")
-
-py_binary(
-    name = "pocket_export_html_to_csv_bin",
-    srcs = ["pocket_export_html_to_csv.py"],
-    visibility = ["//:__subpackages__"],
-    deps = [
-        "@pip//beautifulsoup4",
-    ],
-)
-
-py_binary(
-    name = "youtube_playlist_to_csv_bin",
-    srcs = ["youtube_playlist_to_csv.py"],
-    visibility = ["//:__subpackages__"],
-)
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:private"])
 
-py_library(
+py_binary(
     name = "pocket_export_html_to_csv",
     srcs = ["pocket_export_html_to_csv.py"],
     visibility = ["//:__subpackages__"],
-    deps = [
-        "@pip//beautifulsoup4",
-    ],
+    deps = ["@pip//beautifulsoup4"],
 )
 
-py_library(
+py_binary(
     name = "youtube_playlist_to_csv",
     srcs = ["youtube_playlist_to_csv.py"],
     visibility = ["//:__subpackages__"],

--- a/mchristen/parsing_scripts/pocket_export_html_to_csv.py
+++ b/mchristen/parsing_scripts/pocket_export_html_to_csv.py
@@ -61,6 +61,5 @@ def main():
         })
 
 
-# TODO(https://github.com/bazelbuild/rules_python/pull/1664) fixes this, add with next release
-# if __name__ == '__main__':
-#     main()
+if __name__ == '__main__':
+    main()

--- a/mchristen/parsing_scripts/youtube_playlist_to_csv.py
+++ b/mchristen/parsing_scripts/youtube_playlist_to_csv.py
@@ -59,6 +59,5 @@ def get_rows():
     return rows
 
 
-# TODO(https://github.com/bazelbuild/rules_python/pull/1664) fixes this, add with next release
-# if __name__ == '__main__':
-#     main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Changes:
- adding buildifier. https://github.com/bazelbuild/buildtools, note that this would also allow to use `buildozer`, eg)
- run buildifier to clean up my BUILD files
- Update rules_python and allow py_binary to work again
- Install a bunch of stuff:
  - kicad
  - syncthing
  - AppImage libraries
  - waveform
  - arduino
  - blender
- udev rules for my machine


### Usage Examples:

#### `buildifier`

```
bazel run //:buildifier
```

#### `buildozer`

`input_file.txt`:
```
comment XYZ|//:__pkg__
```

Run with:
```
bazel run --run_under="cd $PWD &&" @com_github_bazelbuild_buildtools//buildozer --  -f input_file.txt
```

### TODO in the Future:
- run buildifier on PR
- register users with dialout
- passwordless sudo
- run syncthing as a service
