### PR TITLE
Show the issue with resolution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -111,10 +111,6 @@ gazelle(
 # gazelle:map_kind grpc_py_library grpc_py_library //bzl:py.bzl
 # gazelle:map_kind proto_py_library proto_py_library //bzl:py.bzl
 
-# TODO: Figure out a way to not need these
-# gazelle:resolve py examples.basic.hello_pb2 //examples/basic:hello_py_library
-# gazelle:resolve py examples.basic.hello_pb2_grpc //examples/basic:hello_grpc_py_library
-
 package(default_visibility = ["//visibility:private"])
 
 # Run as:


### PR DESCRIPTION
Why do I need to add resolve directives to find my generate proto libraries, is there a better way?

One mechanism is using proto_compiled_sources #49 