### PR TITLE
Configure linting to run in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,13 +18,9 @@ jobs:
           # dependencies too
           # Or should we just setup remote caching more fully?
           key: ${{ hashFiles('WORKSPACE') }}
-      # TODO(#57): Re-enable this check when we fix the false errors
-      # - name: bzlmod lockfile
-      #   run: |
-      #     bazel mod deps --lockfile_mode=error
-      - name: Gazelle
+      - name: Lint
         run: |
-          bazel run //:gazelle -- -mode diff
+          ./lint.sh --mode check
       - name: Build
         run: |
           bazel build //...

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -139,3 +139,5 @@ npm.npm_translate_lock(
 use_repo(npm, "npm")
 
 use_repo(pnpm, "pnpm")
+
+bazel_dep(name = "rules_multirun", version = "0.9.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "5ccb020e3cd7bef8eb3f941a023cc1243193e95c53ed12747fd6ed86a8f86368",
+  "moduleFileHash": "78a933871f87bf0fc6820da3b75c41170dbf1ac71de50668d578fb23d6fb73d6",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -270,6 +270,7 @@
         "rules_oci": "rules_oci@1.7.4",
         "buildifier_prebuilt": "buildifier_prebuilt@6.4.0",
         "aspect_rules_js": "aspect_rules_js@1.38.0",
+        "rules_multirun": "rules_multirun@0.9.0",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       }
@@ -1087,6 +1088,37 @@
           "strip_prefix": "rules_js-1.38.0",
           "remote_patches": {
             "https://bcr.bazel.build/modules/aspect_rules_js/1.38.0/patches/module_dot_bazel_version.patch": "sha256-tAqZRfOXAplJDTwXVfUiYwinz9Iqug7CeU2aJH0+IqU="
+          },
+          "remote_patch_strip": 1
+        }
+      }
+    },
+    "rules_multirun@0.9.0": {
+      "name": "rules_multirun",
+      "version": "0.9.0",
+      "key": "rules_multirun@0.9.0",
+      "repoName": "rules_multirun",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "bazel_skylib": "bazel_skylib@1.5.0",
+        "rules_python": "rules_python@0.29.0",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_multirun~0.9.0",
+          "urls": [
+            "https://github.com/keith/rules_multirun/releases/download/0.9.0/rules_multirun.0.9.0.tar.gz"
+          ],
+          "integrity": "sha256-DhJFZ/qFKHh07/M6eRw7vcxTQzKaVvqoKO9iQ4DUYHw=",
+          "strip_prefix": "",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/rules_multirun/0.9.0/patches/module_dot_bazel_version.patch": "sha256-TXZTom3++VxDkbxlgEc85OI7tV6p0Lcr246yGlzsrPQ="
           },
           "remote_patch_strip": 1
         }

--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ bazel run //tools/buildozer -- <args>
 bazel run //tools/buildifier -- <args>
 bazel run -- @pnpm//:pnpm --dir $PWD install --lockfile-only
 ```
+
+#### Inspiration
+
+- https://github.com/jessecureton/python_bazel_template

--- a/lint.sh
+++ b/lint.sh
@@ -2,28 +2,6 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
-
-# Find all Bazel-ish files - these templates come from Buildifier's default search list
-BAZEL_FILES=$(find ${REPO_ROOT} -type f \
-            \(   -name "*.bzl" \
-              -o -name "*.sky" \
-              -o -name "BUILD.bazel" \
-              -o -name "BUILD" \
-              -o -name "*.BUILD" \
-              -o -name "BUILD.*.bazel" \
-              -o -name "BUILD.*.oss" \
-              -o -name "MODULE.bazel" \
-              -o -name "WORKSPACE" \
-              -o -name "WORKSPACE.bazel" \
-              -o -name "WORKSPACE.oss" \
-              -o -name "WORKSPACE.*.bazel" \
-              -o -name "WORKSPACE.*.oss" \) \
-              -print)
-
-# Find all Markdown-ish files
-MARKDOWN_FILES=$(find ${REPO_ROOT} -type f -name "*.md" -print)
-
 # Function to print usage
 print_usage() {
   echo "Usage: $0 --mode [check|format]"
@@ -63,20 +41,33 @@ while true; do
   esac
 done
 
-# Update ARGS based on input
-ISORT_ARGS=("${REPO_ROOT}" "--dont-follow-links")
-BLACK_ARGS=("${REPO_ROOT}")
-FLAKE8_ARGS=("${REPO_ROOT}")
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
+
+# Find all Bazel-ish files - these templates come from Buildifier's default search list
+BAZEL_FILES=$(find ${REPO_ROOT} -type f \
+            \(   -name "*.bzl" \
+              -o -name "*.sky" \
+              -o -name "BUILD.bazel" \
+              -o -name "BUILD" \
+              -o -name "*.BUILD" \
+              -o -name "BUILD.*.bazel" \
+              -o -name "BUILD.*.oss" \
+              -o -name "MODULE.bazel" \
+              -o -name "WORKSPACE" \
+              -o -name "WORKSPACE.bazel" \
+              -o -name "WORKSPACE.oss" \
+              -o -name "WORKSPACE.*.bazel" \
+              -o -name "WORKSPACE.*.oss" \) \
+              -print)
+
+# Find all Markdown-ish files
+MARKDOWN_FILES=$(find ${REPO_ROOT} -type f -name "*.md" -print)
 
 # Check if the flag was set
 if [ -z "$mode" ]; then
   print_usage
 elif [ "$mode" = "check" ]; then
-  # XXX: lint off?
   BUILDIFIER_ARGS=("-lint=off" "-mode=check" "-v=false")
-  ISORT_ARGS+=("--check")
-  BLACK_ARGS+=("--check")
-  # flake8 doesn't format
   PRETTIER_ARGS=("--check" "--config ${REPO_ROOT}/.prettierrc")
   BAZEL_TOOL="//tools:check"
 elif [ "$mode" = "format" ]; then
@@ -84,6 +75,7 @@ elif [ "$mode" = "format" ]; then
   PRETTIER_ARGS=("--write" "--config ${REPO_ROOT}/.prettierrc")
   BAZEL_TOOL="//tools:format"
 fi
+PRETTIER_INVOCATION=""
 
 
 function print_error {
@@ -93,35 +85,15 @@ function print_error {
 }
 trap print_error ERR
 
-#####################
-# Bazel file linting
-#####################
-BUILDIFIER_INVOCATION="bazel run --config quiet -- //tools/buildifier ${BUILDIFIER_ARGS[@]}"
-echo $BAZEL_FILES | xargs ${BUILDIFIER_INVOCATION}
-
-
-#################
-# Python linting
-#################
-# Sort imports
-bazel run --config quiet  -- //tools/isort ${ISORT_ARGS[@]}
-# Autoformat
-bazel run --config quiet -- //tools/black ${BLACK_ARGS[@]}
-# Ensure flake8 compliance
-bazel run --config quiet  -- //tools/flake8 ${FLAKE8_ARGS[@]}
-
-# XXX: Replace most with this
-# bazel run --config quiet ${BAZEL_TOOL}
-
-#################
-# Markdown Linting
-#################
-PRETTIER_INVOCATION="bazel run --config quiet -- //tools/prettier ${PRETTIER_ARGS[@]}"
-echo $MARKDOWN_FILES | xargs ${PRETTIER_INVOCATION}
+CONFIG="--config quiet"
+# Can uncomment to get more verbose
+# CONFIG=""
+echo $BAZEL_FILES | xargs bazel run ${CONFIG} -- //tools/buildifier ${BUILDIFIER_ARGS[@]}
+bazel run ${CONFIG} -- ${BAZEL_TOOL}
+echo $MARKDOWN_FILES | xargs bazel run ${CONFIG} -- //tools/prettier ${PRETTIER_ARGS[@]}
 
 
 printf "\n✨ Linting completed successfully! ✨\n"
 
 # Add git grep XXX?
 # And --check option
-#

--- a/lint.sh
+++ b/lint.sh
@@ -4,17 +4,6 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
 
-function print_error {
-    read line file <<<$(caller)
-    printf "\n⛔️ An error occurred during the following lint step ⛔️\n" >&2
-    sed "${line}q;d" "$file" >&2
-}
-trap print_error ERR
-
-
-#####################
-# Bazel file linting
-#####################
 # Find all Bazel-ish files - these templates come from Buildifier's default search list
 BAZEL_FILES=$(find ${REPO_ROOT} -type f \
             \(   -name "*.bzl" \
@@ -31,30 +20,108 @@ BAZEL_FILES=$(find ${REPO_ROOT} -type f \
               -o -name "WORKSPACE.*.bazel" \
               -o -name "WORKSPACE.*.oss" \) \
               -print)
-BUILDIFIER_ARGS=("-lint=fix" "-mode=fix" "-v=false")
-BUILDIFIER_INVOCATION="bazel run -- //tools/buildifier ${BUILDIFIER_ARGS[@]}"
+
+# Find all Markdown-ish files
+MARKDOWN_FILES=$(find ${REPO_ROOT} -type f -name "*.md" -print)
+
+# Function to print usage
+print_usage() {
+  echo "Usage: $0 --mode [check|format]"
+  exit 1
+}
+
+# Parse arguments using getopt
+OPTS=$(getopt -o '' -l 'mode:' -- "$@")
+if [ $? != 0 ]; then
+  print_usage
+fi
+eval set -- "$OPTS"
+
+# Initialize the flag
+mode=
+
+while true; do
+  case "$1" in
+    --mode)
+      if [ "$2" = "check" ]; then
+        mode=$2
+      elif [ "$2" = "format" ]; then
+        mode=$2
+      else
+        echo "Invalid value for --mode. Use 'check' or 'format'."
+        exit 1
+      fi
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      print_usage
+      ;;
+  esac
+done
+
+# Update ARGS based on input
+ISORT_ARGS=("${REPO_ROOT}" "--dont-follow-links")
+BLACK_ARGS=("${REPO_ROOT}")
+FLAKE8_ARGS=("${REPO_ROOT}")
+
+# Check if the flag was set
+if [ -z "$mode" ]; then
+  print_usage
+elif [ "$mode" = "check" ]; then
+  # XXX: lint off?
+  BUILDIFIER_ARGS=("-lint=off" "-mode=check" "-v=false")
+  ISORT_ARGS+=("--check")
+  BLACK_ARGS+=("--check")
+  # flake8 doesn't format
+  PRETTIER_ARGS=("--check" "--config ${REPO_ROOT}/.prettierrc")
+  BAZEL_TOOL="//tools:check"
+elif [ "$mode" = "format" ]; then
+  BUILDIFIER_ARGS=("-lint=fix" "-mode=fix" "-v=false")
+  PRETTIER_ARGS=("--write" "--config ${REPO_ROOT}/.prettierrc")
+  BAZEL_TOOL="//tools:format"
+fi
+
+
+function print_error {
+    read line file <<<$(caller)
+    printf "\n⛔️ An error occurred during the following lint step ⛔️\n" >&2
+    sed "${line}q;d" "$file" >&2
+}
+trap print_error ERR
+
+#####################
+# Bazel file linting
+#####################
+BUILDIFIER_INVOCATION="bazel run --config quiet -- //tools/buildifier ${BUILDIFIER_ARGS[@]}"
 echo $BAZEL_FILES | xargs ${BUILDIFIER_INVOCATION}
+
 
 #################
 # Python linting
 #################
 # Sort imports
-# XXX: --check-only
-bazel run -- //tools/isort ${REPO_ROOT} --dont-follow-links
+bazel run --config quiet  -- //tools/isort ${ISORT_ARGS[@]}
 # Autoformat
-bazel run -- //tools/black ${REPO_ROOT}
+bazel run --config quiet -- //tools/black ${BLACK_ARGS[@]}
 # Ensure flake8 compliance
-bazel run -- //tools/flake8 ${REPO_ROOT}
+bazel run --config quiet  -- //tools/flake8 ${FLAKE8_ARGS[@]}
+
+# XXX: Replace most with this
+# bazel run --config quiet ${BAZEL_TOOL}
 
 #################
 # Markdown Linting
 #################
-MARKDOWN_FILES=$(find ${REPO_ROOT} -type f -name "*.md" -print)
-PRETTIER_ARGS=("--write" "--config ${REPO_ROOT}/.prettierrc")
-PRETTIER_INVOCATION="bazel run -- //tools/prettier ${PRETTIER_ARGS[@]}"
+PRETTIER_INVOCATION="bazel run --config quiet -- //tools/prettier ${PRETTIER_ARGS[@]}"
 echo $MARKDOWN_FILES | xargs ${PRETTIER_INVOCATION}
 
 
 printf "\n✨ Linting completed successfully! ✨\n"
 
 # Add git grep XXX?
+# And --check option
+#

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,27 @@
+load("//bzl:py.bzl", "py_library")
+load("@rules_multirun//:defs.bzl", "command", "multirun")
+
+command(
+    name = "black_format",
+    command = "//tools/black",
+    environment = {"USE_TARGET_FROM_ENV": "true"},
+)
+# XXX:
+# - Add check
+# - Ensure we are passing the right arguments in
+
+multirun(
+    name = "format",
+    commands = [
+        "black_format",
+    ],
+    jobs = 0,  # Set to 0 to run in parallel, defaults to sequential
+)
+
+package(default_visibility = ["//visibility:private"])
+
+py_library(
+    name = "utils",
+    srcs = ["utils.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,24 +1,75 @@
-load("//bzl:py.bzl", "py_library")
 load("@rules_multirun//:defs.bzl", "command", "multirun")
+load("//bzl:py.bzl", "py_library")
+
+package(default_visibility = ["//visibility:private"])
+
+command(
+    name = "isort_format",
+    args = ["--dont-follow-links"],
+    command = "//tools/isort",
+    environment = {"USE_TARGET_FROM_ENV": "true"},
+)
+
+command(
+    name = "isort_check",
+    args = [
+        "--check",
+        "--dont-follow-links",
+    ],
+    command = "//tools/isort",
+    environment = {"USE_TARGET_FROM_ENV": "true"},
+)
 
 command(
     name = "black_format",
     command = "//tools/black",
     environment = {"USE_TARGET_FROM_ENV": "true"},
 )
-# XXX:
-# - Add check
-# - Ensure we are passing the right arguments in
+
+command(
+    name = "black_check",
+    args = ["--check"],
+    command = "//tools/black",
+    environment = {"USE_TARGET_FROM_ENV": "true"},
+)
+
+# Only checks, just invoke the same way in both usages
+command(
+    name = "flake8",
+    command = "//tools/flake8",
+    environment = {"USE_TARGET_FROM_ENV": "true"},
+)
 
 multirun(
     name = "format",
+    # Buffer the output of the commands and print it after each command has finished.
+    buffer_output = True,
     commands = [
+        # Sort imports
+        "isort_format",
+        # Autoformat
         "black_format",
+        # Ensure flake8 compliance
+        "flake8",
     ],
-    jobs = 0,  # Set to 0 to run in parallel, defaults to sequential
+    # Set to 0 to run in parallel, defaults to sequential
+    # XXX: Maybe formatting needs to be sequential to prevent data races?
+    jobs = 0,
 )
 
-package(default_visibility = ["//visibility:private"])
+multirun(
+    name = "check",
+    # Buffer the output of the commands and print it after each command has finished.
+    buffer_output = True,
+    commands = [
+        "isort_check",
+        "black_check",
+        # Ensure flake8 compliance
+        "flake8",
+    ],
+    # Set to 0 to run in parallel, defaults to sequential
+    jobs = 0,
+)
 
 py_library(
     name = "utils",

--- a/tools/black/BUILD
+++ b/tools/black/BUILD
@@ -7,5 +7,8 @@ py_binary(
     srcs = ["black.py"],
     data = ["//:pyproject.toml"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//black"],
+    deps = [
+        "//tools:utils",
+        "@pip//black",
+    ],
 )

--- a/tools/black/black.py
+++ b/tools/black/black.py
@@ -1,4 +1,3 @@
-import os
 import re
 import sys
 

--- a/tools/black/black.py
+++ b/tools/black/black.py
@@ -1,8 +1,12 @@
+import os
 import re
 import sys
 
 from black import patched_main
 
+from tools import utils
+
 if __name__ == "__main__":
+    utils.update_argv_with_workspace()
     sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
     sys.exit(patched_main())

--- a/tools/flake8/BUILD
+++ b/tools/flake8/BUILD
@@ -7,5 +7,8 @@ py_binary(
     srcs = ["flake8.py"],
     data = ["//:.flake8"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//flake8"],
+    deps = [
+        "//tools:utils",
+        "@pip//flake8",
+    ],
 )

--- a/tools/flake8/flake8.py
+++ b/tools/flake8/flake8.py
@@ -1,4 +1,9 @@
+import sys
+
 from flake8.main import cli
 
+from tools import utils
+
 if __name__ == "__main__":
-    cli.main()
+    utils.update_argv_with_workspace()
+    sys.exit(cli.main())

--- a/tools/isort/BUILD
+++ b/tools/isort/BUILD
@@ -7,5 +7,8 @@ py_binary(
     srcs = ["isort.py"],
     data = ["//:pyproject.toml"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//isort"],
+    deps = [
+        "//tools:utils",
+        "@pip//isort",
+    ],
 )

--- a/tools/isort/isort.py
+++ b/tools/isort/isort.py
@@ -1,4 +1,7 @@
 from isort.main import main
 
+from tools import utils
+
 if __name__ == "__main__":
+    utils.update_argv_with_workspace()
     main()

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+
+def update_argv_with_workspace():
+    """If USE_TARGET_FROM_ENV is set, add BUILD_WORKSPACE_DIRECTORY to sys.argv
+
+    https://bazel.build/docs/user-manual
+    https://bazel.build/reference/be/make-variables
+
+    Rules opt-in by setting the USE_TARGET_FROM_ENV env-var to a truthy
+    statement.
+
+    Raises if USE_TARGET_FROM_ENV is set and BUILD_WORKSPACE_DIRECTORY isn't.
+    If USE_TARGET_FROM_ENV isn't set, does nothing.
+    """
+    if bool(os.environ.get("USE_TARGET_FROM_ENV", False)):
+        # https://bazel.build/docs/user-manual
+        # https://bazel.build/reference/be/make-variables
+        target = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+        if target is None:
+            raise ValueError(
+                "USE_TARGET_FROM_ENV set, but BUILD_WORKSPACE_DIRECTORY unset"
+            )
+        sys.argv.append(target)


### PR DESCRIPTION
Update `./lint.sh` to take a `--mode [check|format]` argument.

Adds `multi_run` dependency so we can run isort/flake8/black all at the same time.