### PR TITLE
Setup remote caching with nativelink

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,13 @@ build --noincompatible_sandbox_hermetic_tmp
 build --action_env=PYTHONNOUSERSITE=1
 build --test_env=PYTHONNOUSERSITE=1
 
+# Remote Cache: https://app.nativelink.com/c690e34c-beac-420a-b672-6320b8f5b419/quickstart
+build --remote_cache=grpcs://cas-michael-christen.build-faster.nativelink.net
+build --remote_header=x-nativelink-api-key=66f9052f8b6613865377d05b5202334eb9a5bb702e64270381c202f6e9ae4072
+build --bes_backend=grpcs://bes-michael-christen.build-faster.nativelink.net
+build --bes_header=x-nativelink-api-key=66f9052f8b6613865377d05b5202334eb9a5bb702e64270381c202f6e9ae4072
+build --remote_timeout=600
+
 # C Compiler Options: https://gcc.gnu.org/onlinedocs/gcc/Option-Summary.html
 
 # All Warnings and then some, mark em as errors too


### PR DESCRIPTION
Configure build to utilize nativelink's remote cache

https://github.com/tracemachina/nativelink