### PR TITLE
Move copts to bzl:cc.bzl and switch to C++23

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
-# Use bzlmod
-common --enable_bzlmod
-
+# See https://bazel.build/docs/user-manual for option definitions
+#
+# Avoid incompatible_sandbox_hermetic_tmp causing relative paths to change.
 # https://github.com/aspect-build/gcc-toolchain/issues/161
 build --noincompatible_sandbox_hermetic_tmp
 
@@ -8,57 +8,20 @@ build --noincompatible_sandbox_hermetic_tmp
 build --action_env=PYTHONNOUSERSITE=1
 build --test_env=PYTHONNOUSERSITE=1
 
-# Remote Cache: https://app.nativelink.com/c690e34c-beac-420a-b672-6320b8f5b419/quickstart
-build --remote_cache=grpcs://cas-michael-christen.build-faster.nativelink.net
-build --remote_header=x-nativelink-api-key=66f9052f8b6613865377d05b5202334eb9a5bb702e64270381c202f6e9ae4072
-build --bes_backend=grpcs://bes-michael-christen.build-faster.nativelink.net
-build --bes_header=x-nativelink-api-key=66f9052f8b6613865377d05b5202334eb9a5bb702e64270381c202f6e9ae4072
-build --remote_timeout=600
-
 # C Compiler Options: https://gcc.gnu.org/onlinedocs/gcc/Option-Summary.html
 
 # All Warnings and then some, mark em as errors too
 build --copt -Wall
-# -Wextra, with a few exceptions
-build --copt -Wmemset-transposed-args
-build --copt -Wcast-function-type
-build --copt -Wclobbered
-build --copt -Wempty-body
-build --copt -Wenum-conversion
-build --copt -Wexpansion-to-defined
-build --copt -Wignored-qualifiers
-# TODO(https://github.com/michael-christen/toolbox/issues/42): Re-enable
-# NOTE: zlib was the cause of requiring this
-# build --copt -Wimplicit-fallthrough=3
-build --copt -Wmaybe-uninitialized
-build --copt -Wshift-negative-value
-build --copt -Wsign-compare
-build --copt -Wstring-compare
-build --copt -Wtype-limits
-build --copt -Wuninitialized
-build --copt -Wunused-but-set-parameter
-build --conlyopt -Wabsolute-value
-build --conlyopt -Wmissing-parameter-type
-build --conlyopt -Wold-style-declaration
-build --conlyopt -Woverride-init
-build --cxxopt -Wsized-deallocation
-build --cxxopt -Wdeprecated-copy
-# Unrecognized
-# build --copt -Walloc-size
-# com_google_protobuf does these:
-# build --copt -Wmissing-field-initializers
-# build --copt -Wredundant-move
-# build --copt -Wunused-parameter
-
 # Warnings are errors
 build --copt -Werror
 
-# Colored output
-build --copt -fdiagnostics-color=always
-
 # Let's use the latest and greatest we can
-build --cxxopt='-std=c++20' --host_cxxopt='-std=c++20'
-# NOTE: Can also specify --linkopt
+# NOTE this should probably match //bzl:cc.bzl
+build --cxxopt='-std=c++23'
+build --host_cxxopt='-std=c++23'
+
+# Note you can use //bzl:cc.bzl c_libary as well to define copts for use with
+# all of our internal cc_libraries
 
 # Only build tests when testing
 test --build_tests_only
@@ -86,3 +49,10 @@ try-import %workspace%/user.bazelrc
 # Must match PYTHON_VERSION in MODULE.bazel
 # LINK(7e463bc3_e4d9_4464_ba39_3217c4a86004)
 common --@aspect_rules_py//py:interpreter_version=3.11.9
+
+# Remote Cache: https://app.nativelink.com/c690e34c-beac-420a-b672-6320b8f5b419/quickstart
+build --remote_cache=grpcs://cas-michael-christen.build-faster.nativelink.net
+build --remote_header=x-nativelink-api-key=66f9052f8b6613865377d05b5202334eb9a5bb702e64270381c202f6e9ae4072
+build --bes_backend=grpcs://bes-michael-christen.build-faster.nativelink.net
+build --bes_header=x-nativelink-api-key=66f9052f8b6613865377d05b5202334eb9a5bb702e64270381c202f6e9ae4072
+build --remote_timeout=600

--- a/bzl/cc.bzl
+++ b/bzl/cc.bzl
@@ -19,65 +19,64 @@
 # directly and include all of the pieces you want
 load("@rules_cc//cc:defs.bzl", _cc_binary = "cc_binary", _cc_library = "cc_library")
 
-
 # C Compiler Options: https://gcc.gnu.org/onlinedocs/gcc/Option-Summary.html
 
 COPTS = [
-  # All Warnings and then some, mark em as errors too
-  '-Wall',
-  # Warnings are errors
-  '-Werror',
-  # -Wextra, with a few exceptions
-  '-Wmemset-transposed-args',
-  '-Wcast-function-type',
-  '-Wclobbered',
-  '-Wempty-body',
-  '-Wenum-conversion',
-  '-Wexpansion-to-defined',
-  '-Wignored-qualifiers',
-  '-Wimplicit-fallthrough=3',
-  '-Wmaybe-uninitialized',
-  '-Wshift-negative-value',
-  '-Wsign-compare',
-  '-Wstring-compare',
-  '-Wtype-limits',
-  '-Wuninitialized',
-  '-Wunused-but-set-parameter',
-  '-Wmissing-field-initializers',
-  '-Wredundant-move',
-  '-Wunused-parameter',
-  # Colored output
-  '-fdiagnostics-color=always',
-  # Unrecognized
-  # '-Walloc-size',
+    # All Warnings and then some, mark em as errors too
+    "-Wall",
+    # Warnings are errors
+    "-Werror",
+    # -Wextra, with a few exceptions
+    "-Wmemset-transposed-args",
+    "-Wcast-function-type",
+    "-Wclobbered",
+    "-Wempty-body",
+    "-Wenum-conversion",
+    "-Wexpansion-to-defined",
+    "-Wignored-qualifiers",
+    "-Wimplicit-fallthrough=3",
+    "-Wmaybe-uninitialized",
+    "-Wshift-negative-value",
+    "-Wsign-compare",
+    "-Wstring-compare",
+    "-Wtype-limits",
+    "-Wuninitialized",
+    "-Wunused-but-set-parameter",
+    "-Wmissing-field-initializers",
+    "-Wredundant-move",
+    "-Wunused-parameter",
+    # Colored output
+    "-fdiagnostics-color=always",
+    # Unrecognized
+    # '-Walloc-size',
 ]
 
 # Add to conly code
 CONLY_OPTS = [
-  '-Wabsolute-value',
-  '-Wmissing-parameter-type',
-  '-Wold-style-declaration',
-  '-Woverride-init',
+    "-Wabsolute-value",
+    "-Wmissing-parameter-type",
+    "-Wold-style-declaration",
+    "-Woverride-init",
 ]
 
 CXX_OPTS = [
-  '-Wsized-deallocation',
-  '-Wdeprecated-copy',
-  # If changing, likely want to update .bazelrc
-  # See https://en.cppreference.com/w/cpp/23
-  '-std=c++23',
+    "-Wsized-deallocation",
+    "-Wdeprecated-copy",
+    # If changing, likely want to update .bazelrc
+    # See https://en.cppreference.com/w/cpp/23
+    "-std=c++23",
 ]
 
 # NOTE: Maybe we should add linkopt too?
 
 def cc_binary(**kwargs):
-    _cc_binary(copts=COPTS + CXX_OPTS, **kwargs)
+    _cc_binary(copts = COPTS + CXX_OPTS, **kwargs)
 
 def cc_library(**kwargs):
-    _cc_library(copts=COPTS + CXX_OPTS, **kwargs)
+    _cc_library(copts = COPTS + CXX_OPTS, **kwargs)
 
 def c_binary(**kwargs):
-    _cc_binary(copts=COPTS + CONLY_OPTS, **kwargs)
+    _cc_binary(copts = COPTS + CONLY_OPTS, **kwargs)
 
 def c_library(**kwargs):
-    _cc_library(copts=COPTS + CONLY_OPTS, **kwargs)
+    _cc_library(copts = COPTS + CONLY_OPTS, **kwargs)

--- a/bzl/cc.bzl
+++ b/bzl/cc.bzl
@@ -1,0 +1,83 @@
+# Custom macros of common cc rules to enable common modifications
+#
+# See https://bazel.build/reference/be/c-cpp for documentation
+#
+# We define our copts in this manner, rather than in .bazelrc to avoid
+# modifying how 3rd party C++ is compiled
+#
+# We have a separate c_binary/c_library defined as a quick work around to give
+# similar resolution of using different copts based on language. Here is how
+# bazel does this internally with command line arguments
+# https://github.com/bazelbuild/bazel/blob/300c5867b7d2da1ba32abc20e95662096c2a7a08/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1244-L1269
+# We could make some more clever rules to do this automatically, but the amount
+# of .c code I write is so miniscule, this shouldn't really be a problem.
+#
+# Note, an alternative would be to modify the cc_toolchain with features, see
+# https://bazel.build/tutorials/ccp-toolchain-config for more info.
+#
+# If you want to use custom COPTS, then just use @rules_cc//cc:defs.bzl
+# directly and include all of the pieces you want
+load("@rules_cc//cc:defs.bzl", _cc_binary = "cc_binary", _cc_library = "cc_library")
+
+
+# C Compiler Options: https://gcc.gnu.org/onlinedocs/gcc/Option-Summary.html
+
+COPTS = [
+  # All Warnings and then some, mark em as errors too
+  '-Wall',
+  # Warnings are errors
+  '-Werror',
+  # -Wextra, with a few exceptions
+  '-Wmemset-transposed-args',
+  '-Wcast-function-type',
+  '-Wclobbered',
+  '-Wempty-body',
+  '-Wenum-conversion',
+  '-Wexpansion-to-defined',
+  '-Wignored-qualifiers',
+  '-Wimplicit-fallthrough=3',
+  '-Wmaybe-uninitialized',
+  '-Wshift-negative-value',
+  '-Wsign-compare',
+  '-Wstring-compare',
+  '-Wtype-limits',
+  '-Wuninitialized',
+  '-Wunused-but-set-parameter',
+  '-Wmissing-field-initializers',
+  '-Wredundant-move',
+  '-Wunused-parameter',
+  # Colored output
+  '-fdiagnostics-color=always',
+  # Unrecognized
+  # '-Walloc-size',
+]
+
+# Add to conly code
+CONLY_OPTS = [
+  '-Wabsolute-value',
+  '-Wmissing-parameter-type',
+  '-Wold-style-declaration',
+  '-Woverride-init',
+]
+
+CXX_OPTS = [
+  '-Wsized-deallocation',
+  '-Wdeprecated-copy',
+  # If changing, likely want to update .bazelrc
+  # See https://en.cppreference.com/w/cpp/23
+  '-std=c++23',
+]
+
+# NOTE: Maybe we should add linkopt too?
+
+def cc_binary(**kwargs):
+    _cc_binary(copts=COPTS + CXX_OPTS, **kwargs)
+
+def cc_library(**kwargs):
+    _cc_library(copts=COPTS + CXX_OPTS, **kwargs)
+
+def c_binary(**kwargs):
+    _cc_binary(copts=COPTS + CONLY_OPTS, **kwargs)
+
+def c_library(**kwargs):
+    _cc_library(copts=COPTS + CONLY_OPTS, **kwargs)

--- a/examples/basic/app/BUILD
+++ b/examples/basic/app/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bzl:cc.bzl", "cc_library", "cc_binary")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/examples/basic/app/BUILD
+++ b/examples/basic/app/BUILD
@@ -1,4 +1,4 @@
-load("//bzl:cc.bzl", "cc_library", "cc_binary")
+load("//bzl:cc.bzl", "cc_binary", "cc_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/examples/basic/lib/BUILD
+++ b/examples/basic/lib/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bzl:cc.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:private"])
 


### PR DESCRIPTION
- On the tin, move copts to bzl:cc.bzl except for a few to allow third party libraries to use different copts
- switch to C++23, everything seems to work alright
- use our new cc_library all over

Resolves #42 