### PR TITLE
Add support for code coverage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,17 +48,17 @@ jobs:
       - name: Coverage Report Generation
         run: |
           # Remove external/ sources: https://manpages.debian.org/unstable/lcov/lcov.1.en.html
-          lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o coverage.txt
+          lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o coverage.dat
           # Show Table
-          lcov --list coverage.txt
+          lcov --list coverage.dat
           # Generate HTML
-          genhtml --legend --highlight --branch-coverage --output genhtml coverage.txt
+          genhtml --legend --highlight --branch-coverage --output genhtml coverage.dat
       # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts
-      - name: Archive coverage.txt
+      - name: Archive coverage.dat
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
-          path: coverage.txt
+          path: coverage.dat
       - name: Archive genhtml
         uses: actions/upload-artifact@v4
         with:
@@ -69,7 +69,7 @@ jobs:
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.txt
+          files: coverage.dat
       # Try out https://app.codecov.io/ or
       # https://github.com/marketplace/actions/report-lcov and ensure min
       # coverage is met

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Test
         run: |
           bazel test //...
-          # XXX: Add all files via a find command and generation
-          # XXX: Should we test in addition / segregate some?
-          # XXX: Should we test in different modes?
-          # XXX: Should we add instrumentation_filter to .bazelrc?
-          #
+          # Food for thought:
+          # - Should we test in addition / segregate some?
+          # - Should we test in different modes (-c opt / -c dbg)?
+          # - Should we add instrumentation_filter to .bazelrc to reduce
+          # analysis cache thrashing?
       - name: Coverage
         run: |
           bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,10 +39,14 @@ jobs:
           # XXX: Should we test in addition / segregate some?
           # XXX: Should we test in different modes?
           # XXX: Should we add instrumentation_filter to .bazelrc?
+          #
       - name: Coverage
         run: |
           bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//"
-          # XXX: Do we need to install lcov?
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
+      - name: Coverage Report Generation
+        run: |
           # Remove external/ sources: https://manpages.debian.org/unstable/lcov/lcov.1.en.html
           lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o coverage.dat
           genhtml --legend --highlight --branch-coverage --output genhtml coverage.dat

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,8 +47,12 @@ jobs:
         uses: hrishikesh-kadam/setup-lcov@v1
       - name: Coverage Report Generation
         run: |
+          # Generate baseline
+          bazel run tools:coverage_baseline -- --root_dir `pwd` > baseline_coverage.dat
           # Remove external/ sources: https://manpages.debian.org/unstable/lcov/lcov.1.en.html
-          lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o coverage.dat
+          lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o most_coverage.dat
+          # Combine with baseline
+          lcov -a baseline_coverage.dat -a most_coverage.dat -o coverage.dat
           # Show Table
           lcov --list coverage.dat
           # Generate HTML

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,6 +49,9 @@ jobs:
         run: |
           # Remove external/ sources: https://manpages.debian.org/unstable/lcov/lcov.1.en.html
           lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o coverage.dat
+          # Show Table
+          lcov --list coverage.dat
+          # Generate HTML
           genhtml --legend --highlight --branch-coverage --output genhtml coverage.dat
       # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts
       - name: Archive coverage.dat
@@ -61,6 +64,12 @@ jobs:
         with:
           name: code-coverage-html
           path: genhtml
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.dat
       # Try out https://app.codecov.io/ or
       # https://github.com/marketplace/actions/report-lcov and ensure min
       # coverage is met

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,4 +35,29 @@ jobs:
       - name: Test
         run: |
           bazel test //...
+          # XXX: Add all files via a find command and generation
+          # XXX: Should we test in addition / segregate some?
+          # XXX: Should we test in different modes?
+          # XXX: Should we add instrumentation_filter to .bazelrc?
+      - name: Coverage
+        run: |
+          bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//"
+          # XXX: Do we need to install lcov?
+          # Remove external/ sources: https://manpages.debian.org/unstable/lcov/lcov.1.en.html
+          lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o coverage.dat
+          genhtml --legend --highlight --branch-coverage --output genhtml coverage.dat
+      # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts
+      - name: Archive coverage.dat
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: coverage.dat
+      - name: Archive genhtml
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-html
+          path: genhtml
+      # Try out https://app.codecov.io/ or
+      # https://github.com/marketplace/actions/report-lcov and ensure min
+      # coverage is met
       - run: echo "Status is ${{ job.status }}."

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,17 +48,17 @@ jobs:
       - name: Coverage Report Generation
         run: |
           # Remove external/ sources: https://manpages.debian.org/unstable/lcov/lcov.1.en.html
-          lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o coverage.dat
+          lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o coverage.txt
           # Show Table
-          lcov --list coverage.dat
+          lcov --list coverage.txt
           # Generate HTML
-          genhtml --legend --highlight --branch-coverage --output genhtml coverage.dat
+          genhtml --legend --highlight --branch-coverage --output genhtml coverage.txt
       # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts
-      - name: Archive coverage.dat
+      - name: Archive coverage.txt
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
-          path: coverage.dat
+          path: coverage.txt
       - name: Archive genhtml
         uses: actions/upload-artifact@v4
         with:
@@ -69,7 +69,7 @@ jobs:
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.dat
+          files: coverage.txt
       # Try out https://app.codecov.io/ or
       # https://github.com/marketplace/actions/report-lcov and ensure min
       # coverage is met

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ CARGO_BAZEL_REPIN=1 bazel sync --only=crate_index
 
 ### Python
 
+#### Excluding coverage
+
+`# pragma: no cover` https://coverage.readthedocs.io/en/latest/excluding.html
+
 #### Adding / Modifying External Dependencies
 
 1. Update `requirements.in`

--- a/bzl/pytest_main.py
+++ b/bzl/pytest_main.py
@@ -22,7 +22,7 @@ def main():
     # https://bazel.build/docs/user-manual#flag--test_filter
     # Take --test_filter options
     test_filter = os.environ.get("TESTBRIDGE_TEST_ONLY", None)
-    if test_filter:
+    if test_filter:  # pragma: no cover
         pytest_args.extend(["-k", test_filter])
 
     # Invoke

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+# The snippet below adds project coverage checks to every PR.
+coverage:
+  status:
+    project: #add everything under here, more options at https://docs.codecov.com/docs/commit-status
+      default:
+        # basic
+        target: auto # default
+        threshold: 0%
+        base: auto 
+# The snippet below adds project coverage reporting to a PR comment from Codecov
+comment:
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: false        # [true :: must have a base report to post]
+  require_head: true       # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]

--- a/examples/basic/BUILD
+++ b/examples/basic/BUILD
@@ -3,7 +3,7 @@ load("@build_stack_rules_proto//rules/cc:proto_cc_library.bzl", "proto_cc_librar
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test", "rust_doc")
 load("//bzl:py.bzl", "grpc_py_library", "proto_py_library", "py_binary", "py_image", "py_test")
 
 package(default_visibility = ["//visibility:private"])
@@ -52,6 +52,16 @@ proto_cc_library(
     hdrs = ["hello.pb.h"],
     visibility = ["//visibility:public"],
     deps = ["@com_google_protobuf//:protobuf"],
+)
+
+rust_library(
+    name = "lib",
+    srcs = ["src/lib.rs"],
+)
+
+rust_test(
+    name = "lib_test",
+    crate = ":lib",
 )
 
 rust_binary(

--- a/examples/basic/BUILD
+++ b/examples/basic/BUILD
@@ -3,7 +3,7 @@ load("@build_stack_rules_proto//rules/cc:proto_cc_library.bzl", "proto_cc_librar
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test", "rust_doc")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc", "rust_library", "rust_test")
 load("//bzl:py.bzl", "grpc_py_library", "proto_py_library", "py_binary", "py_image", "py_test")
 
 package(default_visibility = ["//visibility:private"])

--- a/examples/basic/client.py
+++ b/examples/basic/client.py
@@ -13,11 +13,11 @@ async def get_response() -> hello_pb2.HelloReply:
         return await stub.SayHello(hello_pb2.HelloRequest(name="you"))
 
 
-async def run() -> None:
+async def run() -> None:  # pragma: no cover
     resp = await get_response()
     print("Greeter client received: " + resp.message)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     logging.basicConfig()
     asyncio.run(run())

--- a/examples/basic/grpc_test.py
+++ b/examples/basic/grpc_test.py
@@ -10,7 +10,8 @@ class TestHello(unittest.IsolatedAsyncioTestCase):
         self.server = server.get_server()
         await self.server.start()
 
-    async def asyncTearDown(self):
+    # Why does coverage not see wait_for_termination as ran?
+    async def asyncTearDown(self):  # pragma: no cover
         await self.server.stop(grace=None)
         await self.server.wait_for_termination()
 

--- a/examples/basic/server.py
+++ b/examples/basic/server.py
@@ -25,12 +25,12 @@ def get_server() -> grpc.aio.server:
     return server
 
 
-async def serve() -> None:
+async def serve() -> None:  # pragma no cover
     server = get_server()
     await server.start()
     await server.wait_for_termination()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma no cover
     logging.basicConfig(level=logging.INFO)
     asyncio.run(serve())

--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -1,0 +1,24 @@
+pub struct Greeter {
+    greeting: String,
+}
+
+impl Greeter {
+    pub fn new(greeting: &str) -> Greeter {
+        Greeter { greeting: greeting.to_string(), }
+    }
+
+    pub fn greet(&self, thing: &str) -> String {
+        format!("{} {}", &self.greeting, thing)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Greeter;
+
+    #[test]
+    fn test_greeting() {
+        let hello = Greeter::new("Hi");
+        assert_eq!("Hi Rust", hello.greet("Rust"));
+    }
+}

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,5 +1,7 @@
 load("//bzl:cc.bzl", "cc_library")
 
+package(default_visibility = ["//visibility:private"])
+
 # Alternatively, we could just use @catch2//:catch_main
 cc_library(
     name = "catch_main",
@@ -10,5 +12,3 @@ cc_library(
         "@catch2",
     ],
 )
-
-package(default_visibility = ["//visibility:private"])

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,5 +1,5 @@
 load("@rules_multirun//:defs.bzl", "command", "multirun")
-load("//bzl:py.bzl", "py_library")
+load("//bzl:py.bzl", "py_binary", "py_library")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -82,4 +82,10 @@ py_library(
     srcs = ["bazel_utils.py"],
     visibility = ["//:__subpackages__"],
     deps = ["//third_party/bazel/src/main/protobuf:build_py_library"],
+)
+
+py_binary(
+    name = "coverage_baseline",
+    srcs = ["coverage_baseline.py"],
+    visibility = ["//:__subpackages__"],
 )

--- a/tools/coverage_baseline.py
+++ b/tools/coverage_baseline.py
@@ -1,0 +1,65 @@
+"""Generate a baseline_coverage.dat to get accurate coverage.
+
+`bazel coverage` doesn't include files that weren't included at all, here we
+find all the other files we want and generate a baseline, which gets merged in
+to the overall coverage report.
+"""
+import argparse
+import glob
+import pathlib
+import subprocess
+
+
+def main(root_dir: pathlib.Path):
+    files = sorted(find_files(root_dir))
+    for file in files:
+        print('TN:')
+        print(f'SF:{file}')
+        print('DA:0,0')
+        print('end_of_record')
+
+
+def find_files(root_dir: pathlib.Path) -> list[pathlib.Path]:
+    file_suffixes = [
+        '.h',
+        '.cc',
+        '.rs',
+        '.py',
+    ]
+    # Relative to root
+    ignored_directories = [
+        pathlib.Path(p) for p in [
+            'nobazel',
+            'tools',
+        ]]
+    suffix_args = []
+    for i, suffix in enumerate(file_suffixes):
+        suffix_args.extend(['-name', f'*{suffix}'])
+        if i < len(file_suffixes) - 1:
+            suffix_args.append('-o')
+    # Using find rather than glob at the moment because it allows me to avoid
+    # symlinks easily and I didn't want to bother with anything else
+    find_result = subprocess.check_output(
+        ['find', root_dir, '('] + suffix_args + [')']
+    ).decode('utf-8')
+    paths = []
+    for line in find_result.splitlines():
+        found_path = pathlib.Path(line).relative_to(root_dir)
+        # Exclude ignored_directories
+        ignore_file = False
+        for ignore_dir in ignored_directories:
+            if found_path.is_relative_to(ignore_dir):
+                ignore_file = True
+                break
+        if ignore_file:
+            continue
+        paths.append(found_path)
+    return paths
+
+
+if __name__ == '__main__':
+    # XXX: Pass it in
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root_dir', type=pathlib.Path)
+    args = parser.parse_args()
+    main(root_dir=args.root_dir)

--- a/tools/coverage_baseline.py
+++ b/tools/coverage_baseline.py
@@ -4,8 +4,8 @@
 find all the other files we want and generate a baseline, which gets merged in
 to the overall coverage report.
 """
+
 import argparse
-import glob
 import pathlib
 import subprocess
 
@@ -13,35 +13,37 @@ import subprocess
 def main(root_dir: pathlib.Path):
     files = sorted(find_files(root_dir))
     for file in files:
-        print('TN:')
-        print(f'SF:{file}')
-        print('DA:0,0')
-        print('end_of_record')
+        print("TN:")
+        print(f"SF:{file}")
+        print("DA:0,0")
+        print("end_of_record")
 
 
 def find_files(root_dir: pathlib.Path) -> list[pathlib.Path]:
     file_suffixes = [
-        '.h',
-        '.cc',
-        '.rs',
-        '.py',
+        ".h",
+        ".cc",
+        ".rs",
+        ".py",
     ]
     # Relative to root
     ignored_directories = [
-        pathlib.Path(p) for p in [
-            'nobazel',
-            'tools',
-        ]]
+        pathlib.Path(p)
+        for p in [
+            "nobazel",
+            "tools",
+        ]
+    ]
     suffix_args = []
     for i, suffix in enumerate(file_suffixes):
-        suffix_args.extend(['-name', f'*{suffix}'])
+        suffix_args.extend(["-name", f"*{suffix}"])
         if i < len(file_suffixes) - 1:
-            suffix_args.append('-o')
+            suffix_args.append("-o")
     # Using find rather than glob at the moment because it allows me to avoid
     # symlinks easily and I didn't want to bother with anything else
     find_result = subprocess.check_output(
-        ['find', root_dir, '('] + suffix_args + [')']
-    ).decode('utf-8')
+        ["find", root_dir, "("] + suffix_args + [")"]
+    ).decode("utf-8")
     paths = []
     for line in find_result.splitlines():
         found_path = pathlib.Path(line).relative_to(root_dir)
@@ -57,9 +59,9 @@ def find_files(root_dir: pathlib.Path) -> list[pathlib.Path]:
     return paths
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # XXX: Pass it in
     parser = argparse.ArgumentParser()
-    parser.add_argument('--root_dir', type=pathlib.Path)
+    parser.add_argument("--root_dir", type=pathlib.Path)
     args = parser.parse_args()
     main(root_dir=args.root_dir)

--- a/tools/coverage_baseline.py
+++ b/tools/coverage_baseline.py
@@ -60,7 +60,6 @@ def find_files(root_dir: pathlib.Path) -> list[pathlib.Path]:
 
 
 if __name__ == "__main__":
-    # XXX: Pass it in
     parser = argparse.ArgumentParser()
     parser.add_argument("--root_dir", type=pathlib.Path)
     args = parser.parse_args()


### PR DESCRIPTION
Utilize `bazel coverage` to get coverage information

Utilizes https://github.com/linux-test-project/lcov (installed with https://github.com/hrishikesh-kadam/setup-lcov)
- A decent reverse engineering perspective of lcov: https://github.com/ChrisTimperley/lcovparser.py/blob/main/lcovparser.py
- Here is how to exclude lines: https://stackoverflow.com/questions/23264049/how-to-tell-lcov-to-ignore-lines-in-the-source-files

Uploads to [codecov](https://app.codecov.io/github/michael-christen/toolbox)
- See https://github.com/codecov/codecov-action for configuration of the github action

See https://groups.google.com/g/bazel-discuss/c/igMsIXf0kUQ and https://github.com/bazelbuild/bazel/issues/19357 for a discussion of why bazel doesn't get you "all source files" in coverage. 


### TODO
- [x] add all source files in a baseline.dat that I generate to not get an inflated coverage if something isn't covered at all

### Followups
- Is there a better way to install lcov (part of the image)?
- Add a badge to README https://app.codecov.io/github/michael-christen/toolbox/config/badge
- Try out including embedded coverage: https://github.com/nasa-jpl/embedded-gcov/blob/main/example/example.c / https://www.thanassis.space/coverage.html perhaps https://developer.arm.com/documentation/ihi0014/q/Introduction/About-Embedded-Trace-Macrocells and https://www.trustedfirmware.org/docs/TracebasedCodeCoverageTooling.pdf
- If codecov becomes a pain, try out https://github.com/marketplace/actions/report-lcov
- Maybe I should simply setup a check to compare source files against what is transitively included in tests?