### PR TITLE
Add a buildbuddy workflow and run flakiness check daily

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,7 @@ jobs:
           # - Should we test in different modes (-c opt / -c dbg)?
           # - Should we add instrumentation_filter to .bazelrc to reduce
           # analysis cache thrashing?
+          # Could leave the above to buildbuddy ...
       - name: Coverage
         run: |
           bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//"

--- a/.github/workflows/flakiness.yml
+++ b/.github/workflows/flakiness.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
 jobs:
-  build_and_test:
+  flaky_finder:
     runs-on: ubuntu-latest
     steps:
       - run: echo "The job was triggered by a ${{ github.event_name }} event, running on ${{ runner.os }}, ${{ github.ref }} @ ${{ github.repository }}."

--- a/.github/workflows/flakiness.yml
+++ b/.github/workflows/flakiness.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
+    # Run everyday at 15:00 UTC
+    - cron: "0 15 * * *"
 jobs:
   flaky_finder:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ chmod +x ~/tools/bazel
     - see
       [dashboard](https://app.nativelink.com/c690e34c-beac-420a-b672-6320b8f5b419/dashboard)
       for more detailed metrics.
+  - [buildbuddy](https://app.buildbuddy.io/)
 
 ## References
 

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,5 +1,6 @@
 actions:
   - name: "Build and Test all targets"
+    container_image: "ubuntu-20.04"
     triggers:
       push:
         branches:

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,0 +1,13 @@
+actions:
+  - name: "Build and Test all targets"
+    triggers:
+      push:
+        branches:
+          - "master" # <-- replace "main" with your main branch name
+      pull_request:
+        branches:
+          - "*"
+    bazel_commands:
+      - 'build //...'
+      - 'test //...'
+      - 'coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//"'


### PR DESCRIPTION
On the tin, customize buildbuddy workflow.

The ubuntu version (20.04) is different than what I run (22.04), and github is using ubuntu-latest (22.04)

Also adds a nightly (3pm UTC, 8am PST atm) run of the flakiness check.