### PR TITLE
Add README and furo theme for docs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2130,7 +2130,7 @@
         "recordedFileInputs": {
           "@@pigweed~//pw_env_setup/py/pw_env_setup/virtualenv_setup/upstream_requirements_windows_lock.txt": "4367c7d4cc4a1c2d6a136edace02581066f1c9ead10937685dde568d1061189f",
           "@@pigweed~//pw_env_setup/py/pw_env_setup/virtualenv_setup/upstream_requirements_linux_lock.txt": "ce8b16e007309a610c37eec908b75451733ae5efb9c14ec7e6f04557b81d621e",
-          "@@//requirements_lock.txt": "ce065fba01890e43361089d1fe811e576a35ecff1e104c1f3796d6b6c849aee0",
+          "@@//requirements_lock.txt": "7a4da850ba737d79dc1646c13207ec8b1a4d15b8f42850137a1ac497fde7e2d7",
           "@@pigweed~//pw_env_setup/py/pw_env_setup/virtualenv_setup/upstream_requirements_darwin_lock.txt": "91de3b2cdbe8f8fc7136ce309824355684c2a6ae2395c1e12f4aa59d02d52f3b",
           "@@rules_fuzzing~//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
           "@@nanopb~//extra/requirements_lock.txt": "8a44f53e5c48123742970b4e9d6f8730eaa143134c08db0706ccd6d2c78c03ca",
@@ -2365,6 +2365,16 @@
               "urls": [
                 "https://files.pythonhosted.org/packages/35/3a/ed7b12ecc3f6db2f664ccf85cb2e004d3e90bec928e9d7be6aa2f16b7cdf/mypy-1.11.2-cp312-cp312-macosx_10_9_x86_64.whl"
               ]
+            }
+          },
+          "pip_311_furo": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "pip_311",
+              "requirement": "furo==2024.8.6     --hash=sha256:6cd97c58b47813d3619e63e9081169880fbe331f0ca883c871ff1f3f11814f5c     --hash=sha256:b63e4cee8abfc3136d3bc03a3d45a76a850bada4d6374d24c1716b0e01394a01"
             }
           },
           "pip_311_wheel": {
@@ -2953,6 +2963,16 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
               "repo": "pip_311",
               "requirement": "isoduration==20.11.0     --hash=sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9     --hash=sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          },
+          "pip_311_sphinx_basic_ng": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "pip_311",
+              "requirement": "sphinx-basic-ng==1.0.0b2     --hash=sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9     --hash=sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b"
             }
           },
           "pip_311_typing_extensions": {
@@ -4947,6 +4967,7 @@
                 "cffi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_cffi\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "comm": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_comm\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "fqdn": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_fqdn\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "furo": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_furo\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "idna": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_idna\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "ipdb": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_ipdb\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "jedi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_jedi\",\"target_platforms\":null,\"version\":\"3.11\"}]",
@@ -5052,6 +5073,7 @@
                 "mypy_extensions": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_mypy_extensions\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "python_dateutil": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_python_dateutil\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "snowballstemmer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_snowballstemmer\",\"target_platforms\":null,\"version\":\"3.11\"}]",
+                "sphinx_basic_ng": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_sphinx_basic_ng\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "sphinx_pyscript": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_sphinx_pyscript\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "sphinx_rtd_theme": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_sphinx_rtd_theme\",\"target_platforms\":null,\"version\":\"3.11\"}]",
                 "websocket_client": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":null,\"repo\":\"pip_311_websocket_client\",\"target_platforms\":null,\"version\":\"3.11\"}]",

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 My personal monorepo.
 
+Find [docs here](https://michael-christen.github.io/toolbox)
+
 This will include everything from one-off scripts and experiments to libraries
 and applications. I'll likely mostly use Python, C++, and Rust (fingers crossed)
 and tie it all into 1 build tool to bring them all together.

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -21,6 +21,7 @@ filegroup(
 sphinx_html(
     name = "docs",
     srcs = [
+        "README.md",
         "myst.md",
         # has warnings
         "myst_extensions.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,9 +89,7 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "sphinx_rtd_theme"
-# html_theme = "sphinx_book_theme"
-# html_theme = 'furo'
+html_theme = "furo"
 
 html_static_path = ["_static"]
 # html_logo = "_static/wrench.png"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ documentation for details.
    :maxdepth: 4
    :caption: Contents:
 
+   README
    myst
    examples
    myst_extensions

--- a/gazelle_python.yaml
+++ b/gazelle_python.yaml
@@ -655,6 +655,9 @@ manifest:
     flake8.utils: flake8
     flake8.violation: flake8
     fqdn: fqdn
+    furo: furo
+    furo.navigation: furo
+    furo.sphinxext: furo
     google.protobuf: protobuf
     google.protobuf.any_pb2: protobuf
     google.protobuf.api_pb2: protobuf
@@ -2646,6 +2649,7 @@ manifest:
     sphinx.writers.texinfo: sphinx
     sphinx.writers.text: sphinx
     sphinx.writers.xml: sphinx
+    sphinx_basic_ng: sphinx_basic_ng
     sphinx_copybutton: sphinx_copybutton
     sphinx_design: sphinx_design
     sphinx_design.article_info: sphinx_design
@@ -2952,4 +2956,4 @@ manifest:
     zmq.utils.z85: pyzmq
   pip_repository:
     name: pip
-integrity: c424208a4a3829f96c09986f2efecb7e578cb7c3ed9d96902457467222834c5b
+integrity: d11a127cb9d35eca4847da45112408066f5bea0b35f1a9d73a759b42387f4a4d

--- a/requirements.in
+++ b/requirements.in
@@ -34,3 +34,5 @@ sphinxext-opengraph
 sphinx-pyscript
 sphinx-tippy
 sphinx-togglebutton
+# A more modern sphinx theme
+furo

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -74,6 +74,7 @@ beautifulsoup4==4.12.3 \
     --hash=sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
     # via
     #   -r requirements.in
+    #   furo
     #   nbconvert
     #   sphinx-tippy
 black[jupyter]==24.8.0 \
@@ -338,6 +339,10 @@ fqdn==1.5.1 \
     --hash=sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f \
     --hash=sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014
     # via jsonschema
+furo==2024.8.6 \
+    --hash=sha256:6cd97c58b47813d3619e63e9081169880fbe331f0ca883c871ff1f3f11814f5c \
+    --hash=sha256:b63e4cee8abfc3136d3bc03a3d45a76a850bada4d6374d24c1716b0e01394a01
+    # via -r requirements.in
 grpcio==1.66.1 \
     --hash=sha256:0e6c9b42ded5d02b6b1fea3a25f036a2236eeb75d0579bfd43c0018c88bf0a3e \
     --hash=sha256:161d5c535c2bdf61b95080e7f0f017a1dfcb812bf54093e71e5562b16225b4ce \
@@ -797,6 +802,7 @@ pygments==2.18.0 \
     --hash=sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199 \
     --hash=sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
     # via
+    #   furo
     #   ipython
     #   nbconvert
     #   sphinx
@@ -1151,8 +1157,10 @@ sphinx==7.4.7 \
     --hash=sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239
     # via
     #   -r requirements.in
+    #   furo
     #   myst-parser
     #   sphinx-autoapi
+    #   sphinx-basic-ng
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-pyscript
@@ -1166,6 +1174,10 @@ sphinx-autoapi==3.3.1 \
     --hash=sha256:c31a5f41eabc9705d277b75f98e983d653e9af24e294dd576b2afa1719f72c1f \
     --hash=sha256:e44a225827d0ef7178748225a66f30c95454dfd00ee3c22afbdfb8056f7dffb5
     # via -r requirements.in
+sphinx-basic-ng==1.0.0b2 \
+    --hash=sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9 \
+    --hash=sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b
+    # via furo
 sphinx-copybutton==0.5.2 \
     --hash=sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd \
     --hash=sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e

--- a/tools/sphinx/BUILD
+++ b/tools/sphinx/BUILD
@@ -8,6 +8,7 @@ py_binary(
     tags = ["no-mypy"],
     visibility = ["//visibility:public"],
     deps = [
+        "@pip//furo",  # keep
         "@pip//linkify_it_py",  # keep
         "@pip//myst_parser",  # keep
         "@pip//sphinx",  # keep
@@ -21,6 +22,5 @@ py_binary(
         "@pip//sphinxcontrib_mermaid",  # keep
         "@pip//sphinxext_opengraph",  # keep
         "@pip//sphinxext_rediraffe",  # keep
-        "@pip//furo",  # keep
     ],
 )

--- a/tools/sphinx/BUILD
+++ b/tools/sphinx/BUILD
@@ -21,5 +21,6 @@ py_binary(
         "@pip//sphinxcontrib_mermaid",  # keep
         "@pip//sphinxext_opengraph",  # keep
         "@pip//sphinxext_rediraffe",  # keep
+        "@pip//furo",  # keep
     ],
 )


### PR DESCRIPTION
Play around with furo theme, resolves #118 

Note that the class sections aren't quite as distinct now in autoapi docs, see below for an example:

Before
![image](https://github.com/user-attachments/assets/d4ebacb4-6395-4bcf-a0a0-97de7672afa3)

After
![image](https://github.com/user-attachments/assets/f3a7d2fa-81d0-4158-9458-bd20691ccf61)


Also get README into docs. This is a bit of a hack using a symlink, generally, we don't have a good way to get docs outside of the `docs/` directory into our docs. We could consider using the entire repo for this?