### PR TITLE
Update aspect_bazel_lib

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ module(
 ########################################
 # Generic deps
 ########################################
-bazel_dep(name = "aspect_bazel_lib", version = "2.5.1")
+bazel_dep(name = "aspect_bazel_lib", version = "2.9.3")
 
 ########################################
 # Set up rules_python and pip


### PR DESCRIPTION
Getting error:

```
INFO: Repository aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64 instantiated at:
  <builtin>: in <toplevel>
Repository rule bsdtar_binary_repo defined at:
  /home/buildbuddy/workspace/output-base/external/aspect_bazel_lib~/lib/private/tar_toolchain.bzl:165:37: in <toplevel>
ERROR: An error occurred during the fetch of repository 'aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64':
   Traceback (most recent call last):
        File "/home/buildbuddy/workspace/output-base/external/aspect_bazel_lib~/lib/private/tar_toolchain.bzl", line 144, column 34, in _bsdtar_binary_repo
                rctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [http://security.ubuntu.com/ubuntu/pool/universe/liba/libarchive/libarchive-tools_3.4.0-2ubuntu1.2_amd64.deb] to /home/buildbuddy/workspace/output-base/external/aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64/temp13489321826718935085/libarchive-tools_3.4.0-2ubuntu1.2_amd64.deb: GET returned 404 Not Found
ERROR: no such package '@@aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64//': java.io.IOException: Error downloading [http://security.ubuntu.com/ubuntu/pool/universe/liba/libarchive/libarchive-tools_3.4.0-2ubuntu1.2_amd64.deb] to /home/buildbuddy/workspace/output-base/external/aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64/temp13489321826718935085/libarchive-tools_3.4.0-2ubuntu1.2_amd64.deb: GET returned 404 Not Found
ERROR: /home/buildbuddy/workspace/repo-root/examples/basic/BUILD:141:9: //examples/basic:client_img.interpreter_layer depends on @@aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64//:bsdtar_toolchain in repository @@aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64 which failed to fetch. no such package '@@aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64//': java.io.IOException: Error downloading [http://security.ubuntu.com/ubuntu/pool/universe/liba/libarchive/libarchive-tools_3.4.0-2ubuntu1.2_amd64.deb] to /home/buildbuddy/workspace/output-base/external/aspect_bazel_lib~~toolchains~bsd_tar_linux_amd64/temp13489321826718935085/libarchive-tools_3.4.0-2ubuntu1.2_amd64.deb: GET returned 404 Not Found
ERROR: Analysis of target '//examples/basic:client_img.interpreter_layer' failed; build aborted: Analysis failed
```
https://app.buildbuddy.io/invocation/8aa5e0f4-58c5-426a-b816-5247aeb4b93b#@88

Let's see if bumping version fixes it.