### PR TITLE
Setup pigweed platform builds as a separate third_party folder for the most part

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -142,7 +142,7 @@ filegroup(
         "//examples/basic:python_source",
         "//examples/bazel:python_source",
         "//examples/pigweed/modules/blinky:python_source",
-        "//examples/pigweed/tools:python_source",
+        "//third_party/pigweed/tools:python_source",
     ],
     visibility = ["//visibility:public"],
 )

--- a/examples/pigweed/apps/blinky/BUILD
+++ b/examples/pigweed/apps/blinky/BUILD
@@ -1,7 +1,7 @@
 load("@pigweed//targets/host_device_simulator:transition.bzl", "host_device_simulator_binary")
 load("//third_party/pigweed/tools:tools.bzl", "host_console")
 
-package(default_visibility = ["//visibility:private"])
+package(default_visibility = ["//visibility:public"])
 
 cc_binary(
     name = "blinky",

--- a/examples/pigweed/apps/blinky/BUILD
+++ b/examples/pigweed/apps/blinky/BUILD
@@ -1,14 +1,14 @@
 load("@pigweed//targets/host_device_simulator:transition.bzl", "host_device_simulator_binary")
-load("//examples/pigweed/tools:tools.bzl", "host_console")
+load("//third_party/pigweed/tools:tools.bzl", "host_console")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 cc_binary(
     name = "blinky",
     srcs = ["main.cc"],
     deps = [
         "//examples/pigweed/modules/blinky:service",
-        "//examples/pigweed/system",
+        "//examples/pigweed/apps/blinky/system",
         "@pigweed//pw_log",
         "@pigweed//pw_system:async",
 

--- a/examples/pigweed/apps/blinky/system/BUILD
+++ b/examples/pigweed/apps/blinky/system/BUILD
@@ -1,0 +1,44 @@
+load("@pigweed//pw_build:compatibility.bzl", "host_backend_alias", "incompatible_with_mcu")
+
+# gazelle:default_visibility //visibility:public
+package(default_visibility = ["//visibility:public"])
+
+label_flag(
+    name = "system",
+    build_setting_default = ":unspecified_backend",
+)
+
+host_backend_alias(
+    name = "unspecified_backend",
+    backend = ":host_system",
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [
+        "system.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pigweed//pw_digital_io",
+    ],
+)
+
+cc_library(
+    name = "host_system",
+    srcs = [
+        "host_led.cc",
+        "host_system.cc",
+    ],
+    implementation_deps = [
+        "@pigweed//pw_channel",
+        "@pigweed//pw_channel:stream_channel",
+        "@pigweed//pw_digital_io",
+        "@pigweed//pw_digital_io:digital_io_mock",
+        "@pigweed//pw_multibuf:simple_allocator",
+        "@pigweed//pw_system:async",
+        "@pigweed//pw_system:io",
+    ],
+    target_compatible_with = incompatible_with_mcu(),
+    deps = ["//examples/pigweed/apps/blinky/system:headers"],
+)

--- a/examples/pigweed/apps/blinky/system/host_led.cc
+++ b/examples/pigweed/apps/blinky/system/host_led.cc
@@ -11,24 +11,16 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-#define PW_LOG_MODULE_NAME "MAIN"
 
 #include "examples/pigweed/apps/blinky/system/system.h"
-#include "examples/pigweed/modules/blinky/service.h"
-#include "pw_log/log.h"
-#include "pw_system/system.h"
+#include "pw_digital_io/digital_io_mock.h"
 
-int main() {
-  demo::system::Init();
-  auto& rpc_server = pw::System().rpc_server();
-  auto& monochrome_led = demo::system::MonochromeLed();
+namespace demo::system {
 
-  static demo::BlinkyService blinky_service;
-  blinky_service.Init(pw::System().dispatcher(), pw::System().allocator(),
-                      monochrome_led);
-  rpc_server.RegisterService(blinky_service);
-
-  PW_LOG_INFO("Started blinky app; waiting for RPCs...");
-  demo::system::Start();
-  PW_UNREACHABLE;
+pw::digital_io::DigitalInOut& MonochromeLed() {
+  static constexpr size_t kCapacity = 256;
+  static pw::digital_io::DigitalInOutMock<kCapacity> digital_io_mock;
+  return digital_io_mock;
 }
+
+}  // namespace demo::system

--- a/examples/pigweed/apps/blinky/system/host_system.cc
+++ b/examples/pigweed/apps/blinky/system/host_system.cc
@@ -1,0 +1,76 @@
+// Copyright 2024 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include <signal.h>
+#include <stdio.h>
+
+#include "pw_assert/check.h"
+#include "pw_channel/stream_channel.h"
+#include "pw_digital_io/digital_io.h"
+#include "pw_multibuf/simple_allocator.h"
+#include "pw_system/io.h"
+#include "pw_system/system.h"
+#include "pw_thread_stl/options.h"
+
+using ::pw::channel::StreamChannel;
+using ::pw::digital_io::DigitalIn;
+using ::pw::digital_io::State;
+
+extern "C" {
+
+void CtrlCSignalHandler(int /* ignored */) {
+  printf("\nCtrl-C received; simulator exiting immediately...\n");
+  // Skipping the C++ destructors since we want to exit immediately.
+  _exit(0);
+}
+
+}  // extern "C"
+
+void InstallCtrlCSignalHandler() {
+  // Catch Ctrl-C to force a 0 exit code (success) to avoid signaling an error
+  // for intentional exits. For example, VSCode shows an alarming dialog on
+  // non-zero exit, which is confusing for users intentionally quitting.
+  signal(SIGINT, CtrlCSignalHandler);
+}
+
+namespace demo::system {
+
+void Init() {}
+
+void Start() {
+  InstallCtrlCSignalHandler();
+  printf("==========================================\n");
+  printf("=== Pigweed Quickstart: Host Simulator ===\n");
+  printf("==========================================\n");
+  printf("Simulator is now running. To connect with a console,\n");
+  printf("either run one in a new terminal:\n");
+  printf("\n");
+  printf("   $ bazelisk run //blinky:simulator_console\n");
+  printf("\n");
+  printf("one from VSCode under the 'Bazel Build Targets' explorer tab.\n");
+  printf("\n");
+  printf("Press Ctrl-C to exit\n");
+
+  static std::byte channel_buffer[16384];
+  static pw::multibuf::SimpleAllocator multibuf_alloc(channel_buffer,
+                                                      pw::System().allocator());
+  static pw::NoDestructor<StreamChannel> channel(
+      multibuf_alloc, pw::system::GetReader(), pw::thread::stl::Options(),
+      pw::system::GetWriter(), pw::thread::stl::Options());
+
+  pw::SystemStart(*channel);
+  PW_UNREACHABLE;
+}
+
+}  // namespace demo::system

--- a/examples/pigweed/apps/blinky/system/system.h
+++ b/examples/pigweed/apps/blinky/system/system.h
@@ -1,0 +1,31 @@
+// Copyright 2024 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+#include "pw_digital_io/digital_io.h"
+
+// The functions in this file return specific implementations of singleton types
+// provided by the system.
+
+namespace demo::system {
+
+/// Initializes the system. This must be called before anything else in `main`.
+void Init();
+
+/// Starts the main system scheduler. This function never returns.
+[[noreturn]] void Start();
+
+pw::digital_io::DigitalInOut& MonochromeLed();
+
+}  // namespace demo::system

--- a/examples/pigweed/modules/blinky/BUILD
+++ b/examples/pigweed/modules/blinky/BUILD
@@ -40,8 +40,8 @@ cc_library(
         "@pigweed//pw_preprocessor",
     ],
     deps = [
+        "//examples/pigweed/apps/blinky/system",
         "//examples/pigweed/modules/timer_future",
-        "//examples/pigweed/system",
         "@pigweed//pw_async2:coro",
         "@pigweed//pw_async2:coro_or_else_task",
         "@pigweed//pw_async2:dispatcher",

--- a/examples/pigweed/modules/timer_future/BUILD
+++ b/examples/pigweed/modules/timer_future/BUILD
@@ -12,12 +12,13 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 cc_library(
     name = "timer_future",
     srcs = ["timer_future.cc"],
     hdrs = ["timer_future.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "@pigweed//pw_async2:dispatcher",
         "@pigweed//pw_chrono:system_clock",

--- a/examples/pigweed/modules/timer_future/BUILD
+++ b/examples/pigweed/modules/timer_future/BUILD
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-package(default_visibility = ["//visibility:private"])
+package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "timer_future",

--- a/third_party/pigweed/.pw_console.yaml
+++ b/third_party/pigweed/.pw_console.yaml
@@ -1,0 +1,62 @@
+# This is a pw_console config file that defines a default window layout.
+# For more info on what can be added to this file see:
+#   https://pigweed.dev/pw_console/py/pw_console/docs/user_guide.html#configuration
+config_title: pw_console
+
+# Window layout
+windows:
+  # Left split with tabbed views.
+  Split 1 tabbed:
+    Python Repl:
+      hidden: False
+  # Right split with stacked views.
+  Split 2 stacked:
+    Device Logs:
+      hidden: False
+    Host Logs:
+      hidden: False
+
+window_column_split_method: vertical
+# window_column_split_method: horizontal
+
+# Default colors:
+ui_theme: dark
+code_theme: pigweed-code
+swap_light_and_dark: False
+
+# A few other choices:
+# ui_theme: high-contrast-dark
+# ui_theme: nord
+# ui_theme: synthwave84
+# code_theme: gruvbox-dark
+# code_theme: pigweed-code-light
+# code_theme: synthwave84
+
+# Log display options:
+spaces_between_columns: 2
+hide_date_from_log_time: True
+recolor_log_lines_to_match_level: False
+
+column_order:
+  # Column name
+  - time
+  - level
+  - timestamp
+  - module
+  # Hidden:
+  # - source_name
+
+column_order_omit_unspecified_columns: True
+
+snippets:
+  Echo RPC:
+    code: |
+      device.rpcs.pw.rpc.EchoService.Echo(msg='hello world')
+    description: |
+      Send a string to the device and receive a response with the same
+      message back.
+
+      ```pycon
+      >>> device.rpcs.pw.rpc.EchoService.Echo(msg='hello world')
+      (Status.OK, pw.rpc.EchoMessage(msg='hello world'))
+      ```

--- a/third_party/pigweed/BUILD
+++ b/third_party/pigweed/BUILD
@@ -1,0 +1,12 @@
+# Keep things easy for now
+# gazelle:default_visibility //visibility:public
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "pw_console_config",
+    srcs = [
+        ".pw_console.yaml",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/pigweed/README.external.md
+++ b/third_party/pigweed/README.external.md
@@ -1,0 +1,8 @@
+From a few pigweed repos:
+
+- https://github.com/google/pigweed
+- https://pigweed.googlesource.com/pigweed/showcase/sense/
+
+Apache-2.0 license
+
+Vendor in a few files.

--- a/third_party/pigweed/platforms/rp2/BUILD
+++ b/third_party/pigweed/platforms/rp2/BUILD
@@ -1,0 +1,71 @@
+# XXX: Originally from sense
+
+package(default_visibility = ["//visibility:public"])
+
+# This is an incomplete platform, do NOT try to pass this
+# as a --platforms flag value. Use :rp2040 or :rp2350.
+platform(
+    name = "rp2_common",
+    constraint_values = [
+        "@freertos//:disable_task_statics",
+        "@pigweed//pw_build/constraints/rtos:freertos",
+        "@pigweed//pw_build/constraints/chipset:rp2040",  # TODO: https://pwbug.dev/343487589 - Use Pico SDK constraints.
+        "@pigweed//pw_cpu_exception:enabled",
+        "@pigweed//pw_interrupt_cortex_m:backend",
+        "@platforms//os:none",
+    ],
+)
+
+platform(
+    name = "rp2040",
+    constraint_values = [
+        "@freertos//:port_ARM_CM0",
+        "@pico-sdk//bazel/constraint:rp2040",
+        # For toolchain selection.
+        "@platforms//cpu:armv6-m",
+        "@pw_toolchain//constraints/arm_mcpu:cortex-m0",
+    ],
+    parents = [":rp2_common"],
+)
+
+platform(
+    name = "rp2350",
+    constraint_values = [
+        "@freertos//:port_ARM_CM33_NTZ",
+        "@pico-sdk//bazel/constraint:rp2350",
+        # For toolchain selection.
+        "@platforms//cpu:armv8-m",
+        "@pw_toolchain//constraints/arm_mcpu:cortex-m33",
+    ],
+    parents = [":rp2_common"],
+)
+
+cc_library(
+    name = "extra_platform_libs",
+    deps = [
+        "@pico-sdk//src/rp2_common/pico_stdlib:pico_stdlib",
+        "@pigweed//pw_tokenizer:linker_script",
+    ] + select({
+        "@rules_cc//cc/compiler:clang": [
+            "@pigweed//pw_libcxx",
+        ],
+        "//conditions:default": [],
+    }),
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "freertos_config",
+    hdrs = [
+        "config/FreeRTOSConfig.h",
+    ],
+    includes = ["config"],
+    deps = ["@pigweed//third_party/freertos:config_assert"],
+)
+
+cc_library(
+    name = "thread_config_overrides",
+    defines = [
+        "PW_THREAD_FREERTOS_CONFIG_JOINING_ENABLED=1",
+    ],
+)

--- a/third_party/pigweed/platforms/rp2/binary.bzl
+++ b/third_party/pigweed/platforms/rp2/binary.bzl
@@ -1,0 +1,94 @@
+"""Project-specific bazel transitions for rp2xxx-series chips.
+
+TODO:  b/301334234 - Use platform-based flags and retire these transitions.
+
+Originally sourced from https://pigweed.googlesource.com/pigweed/showcase/sense/ with modifications
+"""
+
+load("@pigweed//pw_build:merge_flags.bzl", "merge_flags_for_transition_impl", "merge_flags_for_transition_outputs")
+load("@pigweed//targets/rp2040:transition.bzl", "RP2_SYSTEM_FLAGS")
+
+_COMMON_FLAGS = merge_flags_for_transition_impl(
+    base = RP2_SYSTEM_FLAGS,
+    override = {
+        "@freertos//:freertos_config": "//third_party/pigweed/platforms/rp2:freertos_config",
+        "@pico-sdk//bazel/config:PICO_CLIB": "llvm_libc",
+        "@pico-sdk//bazel/config:PICO_TOOLCHAIN": "clang",
+        "@pigweed//pw_build:default_module_config": "//system:module_config",
+        "@pigweed//pw_system:extra_platform_libs": "//third_party/pigweed/platforms/rp2:extra_platform_libs",
+        "@pigweed//pw_system:io_backend": "@pigweed//pw_system:sys_io_target_io",
+        "@pigweed//pw_toolchain:cortex-m_toolchain_kind": "clang",
+        "@pigweed//pw_unit_test:config_override": "//third_party/pigweed/platforms/rp2:64k_unit_tests",
+    },
+)
+
+_RP2040_FLAGS = {
+    "//command_line_option:platforms": "//third_party/pigweed/platforms/rp2:rp2040",
+}
+
+_RP2350_FLAGS = {
+    "//command_line_option:platforms": "//third_party/pigweed/platforms/rp2:rp2350",
+}
+
+def _rp2_transition(device_specific_flags, app_flags):
+    total_flags = dict(device_specific_flags, **app_flags)
+
+    def _rp2_transition_impl(settings, attr):
+        # buildifier: disable=unused-variable
+        _ignore = settings, attr
+        return merge_flags_for_transition_impl(
+            base = _COMMON_FLAGS,
+            override = total_flags,
+        )
+
+    return transition(
+        implementation = _rp2_transition_impl,
+        inputs = [],
+        outputs = merge_flags_for_transition_outputs(
+            base = _COMMON_FLAGS,
+            override = total_flags,
+        ),
+    )
+
+def _rp2_binary_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.symlink(output = out, is_executable = True, target_file = ctx.executable.binary)
+    return [DefaultInfo(files = depset([out]), executable = out)]
+
+def define_rp2040_binary_rule(app_flags):
+    return rule(
+        _rp2_binary_impl,
+        attrs = {
+            "binary": attr.label(
+                doc = "cc_binary to build for the rp2040",
+                cfg = _rp2_transition(_RP2040_FLAGS, app_flags),
+                executable = True,
+                mandatory = True,
+            ),
+            "_allowlist_function_transition": attr.label(
+                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            ),
+        },
+        doc = "Builds the specified binary for the rp2040 platform",
+        # This target is for rp2040 and can't be run on host.
+        executable = False,
+    )
+
+def define_rp2350_binary_rule(app_flags):
+    return rule(
+        _rp2_binary_impl,
+        attrs = {
+            "binary": attr.label(
+                doc = "cc_binary to build for the rp2350",
+                cfg = _rp2_transition(_RP2350_FLAGS, app_flags),
+                executable = True,
+                mandatory = True,
+            ),
+            "_allowlist_function_transition": attr.label(
+                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            ),
+        },
+        doc = "Builds the specified binary for the rp2350 platform",
+        # This target is for rp2350 and can't be run on host.
+        executable = False,
+    )

--- a/third_party/pigweed/platforms/rp2/config/FreeRTOSConfig.h
+++ b/third_party/pigweed/platforms/rp2/config/FreeRTOSConfig.h
@@ -1,0 +1,113 @@
+// Copyright 2024 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+#include <stdint.h>
+
+// Disable formatting to make it easier to compare with other config files.
+// clang-format off
+
+extern uint32_t SystemCoreClock;
+
+#define vPortSVCHandler         SVC_Handler
+#define xPortPendSVHandler      PendSV_Handler
+#define xPortSysTickHandler     SysTick_Handler
+
+#if __ARM_FP
+#define configENABLE_FPU                        1
+#else
+#define configENABLE_FPU                        0
+#endif  // __ARM_FP
+
+// TODO: Set up the MPU.
+#define configENABLE_MPU                        0
+#define configENABLE_TRUSTZONE                  0
+#define configRUN_FREERTOS_SECURE_ONLY          1
+
+#define configUSE_PREEMPTION                    1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+#define configUSE_TICKLESS_IDLE                 0
+#define configCPU_CLOCK_HZ                      (SystemCoreClock)
+#define configTICK_RATE_HZ                      ((TickType_t)1000)
+#define configMAX_PRIORITIES                    5
+#define configMINIMAL_STACK_SIZE                ((uint32_t)(256))
+#define configMAX_TASK_NAME_LEN                 16
+#define configUSE_16_BIT_TICKS                  0
+#define configIDLE_SHOULD_YIELD                 1
+#define configUSE_TASK_NOTIFICATIONS            1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES   3
+#define configUSE_MUTEXES                       1
+#define configUSE_RECURSIVE_MUTEXES             0
+#define configUSE_COUNTING_SEMAPHORES           1
+#define configQUEUE_REGISTRY_SIZE               10
+#define configUSE_QUEUE_SETS                    0
+#define configUSE_TIME_SLICING                  1
+#define configUSE_NEWLIB_REENTRANT              0
+#define configENABLE_BACKWARD_COMPATIBILITY     0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS 5
+#define configSTACK_DEPTH_TYPE                  uint32_t
+#define configMESSAGE_BUFFER_LENGTH_TYPE        size_t
+
+#define configSUPPORT_STATIC_ALLOCATION         1
+#define configSUPPORT_DYNAMIC_ALLOCATION        0
+#define configTOTAL_HEAP_SIZE                   ((size_t)(1 * 1024))
+#define configAPPLICATION_ALLOCATED_HEAP        1
+
+#define configUSE_IDLE_HOOK                     0
+#define configUSE_TICK_HOOK                     0
+#define configCHECK_FOR_STACK_OVERFLOW          0
+#define configUSE_MALLOC_FAILED_HOOK            0
+#define configUSE_DAEMON_TASK_STARTUP_HOOK      0
+
+#define configGENERATE_RUN_TIME_STATS           0
+#define configUSE_TRACE_FACILITY                0
+#define configUSE_STATS_FORMATTING_FUNCTIONS    0
+
+#define configUSE_CO_ROUTINES                   0
+#define configMAX_CO_ROUTINE_PRIORITIES         1
+
+#define configUSE_TIMERS                        1
+#define configTIMER_TASK_PRIORITY               3
+#define configTIMER_QUEUE_LENGTH                10
+#define configTIMER_TASK_STACK_DEPTH            configMINIMAL_STACK_SIZE
+
+/* __NVIC_PRIO_BITS in CMSIS */
+#define configPRIO_BITS 4
+
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY ((1U << (configPRIO_BITS)) - 1)
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY 2
+#define configKERNEL_INTERRUPT_PRIORITY (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+
+// Instead of defining configASSERT(), include a header that provides a
+// definition that redirects to pw_assert.
+#include "pw_third_party/freertos/config_assert.h"
+
+#define INCLUDE_vTaskPrioritySet                1
+#define INCLUDE_uxTaskPriorityGet               1
+#define INCLUDE_vTaskDelete                     1
+#define INCLUDE_vTaskSuspend                    1
+#define INCLUDE_xResumeFromISR                  1
+#define INCLUDE_vTaskDelayUntil                 1
+#define INCLUDE_vTaskDelay                      1
+#define INCLUDE_xTaskGetSchedulerState          1
+#define INCLUDE_xTaskGetCurrentTaskHandle       1
+#define INCLUDE_uxTaskGetStackHighWaterMark     0
+#define INCLUDE_xTaskGetIdleTaskHandle          0
+#define INCLUDE_eTaskGetState                   0
+#define INCLUDE_xEventGroupSetBitFromISR        1
+#define INCLUDE_xTimerPendFunctionCall          0
+#define INCLUDE_xTaskAbortDelay                 0
+#define INCLUDE_xTaskGetHandle                  0
+#define INCLUDE_xTaskResumeFromISR              1

--- a/third_party/pigweed/tools/BUILD
+++ b/third_party/pigweed/tools/BUILD
@@ -1,0 +1,24 @@
+# gazelle:map_kind py_binary py_binary @rules_python//python:defs.bzl
+
+load("@rules_python//python:defs.bzl", "py_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "python_source",
+    srcs = glob(["*.py"]) + [
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "console",
+    srcs = ["console.py"],
+    # TODO(#111): pigweed isn't setup for use with mypy yet
+    tags = ["no-mypy"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//examples/pigweed/modules/blinky:blinky_pb2",
+        "@pigweed//pw_system/py:pw_system_lib",
+    ],
+)

--- a/third_party/pigweed/tools/console.py
+++ b/third_party/pigweed/tools/console.py
@@ -27,11 +27,9 @@ from pw_system.device_connection import (
 )
 
 from examples.pigweed.modules.blinky import blinky_pb2
-from hw_services.sbr import sbr_pb2
 
 COMPILED_PROTOS = [
     blinky_pb2,
-    sbr_pb2,
 ]
 _LOG = logging.getLogger(__file__)
 

--- a/third_party/pigweed/tools/console.py
+++ b/third_party/pigweed/tools/console.py
@@ -1,0 +1,102 @@
+# Copyright 2024 The Pigweed Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+"""Wraps pw_system's console to inject quickstart's RPC proto."""
+
+import argparse
+import logging
+import sys
+
+import pw_cli
+import pw_system.console
+from pw_system.device import Device as PwSystemDevice
+from pw_system.device_connection import DeviceConnection
+from pw_system.device_connection import add_device_args
+from pw_system.device_connection import (
+    create_device_serial_or_socket_connection,
+)
+
+from examples.pigweed.modules.blinky import blinky_pb2
+from hw_services.sbr import sbr_pb2
+
+COMPILED_PROTOS = [
+    blinky_pb2,
+    sbr_pb2,
+]
+_LOG = logging.getLogger(__file__)
+
+
+# Quickstart-specific device classes, new functions can be added here.
+# similar to ones on the parent pw_system.device.Device class:
+# https://cs.opensource.google/pigweed/pigweed/+/main:pw_system/py/pw_system/device.py?q=%22def%20run_tests(%22
+class Device(PwSystemDevice):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def toggle_led(self):
+        """Toggles the onboard (non-RGB) LED."""
+        self.rpcs.blinky.Blinky.ToggleLed()
+
+    def set_led(self, on: bool):
+        """Sets the onboard (non-RGB) LED."""
+        self.rpcs.blinky.Blinky.SetLed(on=on)
+
+    def blink(self, interval_ms=1000, blink_count=None):
+        """Sets the onboard (non-RGB) LED to blink on and off."""
+        self.rpcs.blinky.Blinky.Blink(
+            interval_ms=interval_ms, blink_count=blink_count
+        )
+
+
+def get_device_connection(
+    setup_logging: bool = True,
+    log_level: int = logging.DEBUG,
+) -> DeviceConnection:
+    if setup_logging:
+        pw_cli.log.install(level=log_level)
+
+    parser = argparse.ArgumentParser(
+        prog="quickstart",
+        description=__doc__,
+    )
+    parser = add_device_args(parser)
+    args, _remaning_args = parser.parse_known_args()
+
+    device_context = create_device_serial_or_socket_connection(
+        device=args.device,
+        baudrate=args.baudrate,
+        token_databases=args.token_databases,
+        compiled_protos=COMPILED_PROTOS,
+        socket_addr=args.socket_addr,
+        ticks_per_second=args.ticks_per_second,
+        serial_debug=args.serial_debug,
+        rpc_logging=args.rpc_logging,
+        hdlc_encoding=args.hdlc_encoding,
+        channel_id=args.channel_id,
+        # Device tracing is not hooked up yet for Pigweed Sense.
+        device_tracing=False,
+        device_class=Device,
+    )
+
+    return device_context
+
+
+def main() -> int:
+    return pw_system.console.main(
+        compiled_protos=COMPILED_PROTOS,
+        device_connection=get_device_connection(),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/pigweed/tools/tools.bzl
+++ b/third_party/pigweed/tools/tools.bzl
@@ -1,0 +1,68 @@
+# Copyright 2024 The Pigweed Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+def host_console(name, binary, extra_args = []):
+    """Create a host binary console run target.
+
+    Args:
+      name: target name
+      binary: target binary the console is for
+      extra_args: additional arguments added to the console invocation
+    """
+    native_binary(
+        name = name,
+        src = "//third_party/pigweed/tools:console",
+        args = [
+            # This arg lets us skip manual port selection.
+            "--socket",
+            "default",
+            "--config-file",
+            "$(rootpath //third_party/pigweed:pw_console_config)",
+        ] + extra_args,
+        data = [
+            binary,
+            "//third_party/pigweed:pw_console_config",
+        ],
+    )
+
+def device_console(name, binary, extra_args = []):
+    """Create a device binary console run target.
+
+    Makes running a console for a binary easy, and ensures the associated binary is
+    up to date (but does not flash the device).
+
+    Args:
+      name: target name
+      binary: target binary the console is for
+      extra_args: additional arguments added to the console invocation
+    """
+    native_binary(
+        name = name,
+        src = "//third_party/pigweed/tools:console",
+        args = [
+            "-b",
+            "115200",
+            "--token-databases",
+            "$(rootpath " + binary + ")",
+            "--config-file",
+            "$(rootpath //third_party/pigweed:pw_console_config)",
+        ] + extra_args,
+        data = [
+            binary,
+            # XXX: May want to make this a bit more configurable
+            "//third_party/pigweed:pw_console_config",
+        ],
+    )


### PR DESCRIPTION
Attempt to segregate most of the pigweed marked libraries in order to use them as the library they are / keep apache 2 in tact for them.