### PR TITLE
Setup our first hardware driver (hw_drivers) for LIS3MDL Magnetometer

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,8 @@ workspace(name = "mchristen")
 #
 # Alternative to gcc-toolchain: https://github.com/uber/hermetic_cc_toolchain
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 # Load the http_archive rule so that we can have bazel download
 # various rulesets and dependencies.
 # The `load` statement imports the symbol for http_archive from the http.bzl
@@ -122,3 +124,12 @@ load("@rules_python_gazelle_plugin//:deps.bzl", _py_gazelle_deps = "gazelle_deps
 # This rule loads and compiles various go dependencies that running gazelle
 # for python requirements.
 _py_gazelle_deps()
+
+# TODO: https://pwbug.dev/354747966 - Update the BCR version of Emboss.
+git_repository(
+    name = "com_google_emboss",
+    # LINT.IfChange(emboss)
+    remote = "https://pigweed.googlesource.com/third_party/github/google/emboss",
+    tag = "v2024.0809.170004",
+    # LINT.ThenChange(/pw_package/py/pw_package/packages/emboss.py:emboss)
+)

--- a/hw_drivers/lis3mdl/BUILD
+++ b/hw_drivers/lis3mdl/BUILD
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:private"])
 emboss_cc_library(
     name = "lis3mdl_emb",
     srcs = ["lis3mdl.emb"],
-    # XXX: Required for cross-compilation, investigate more
+    # TODO(#144): Required for cross-compilation, investigate more
     enable_enum_traits = False,
     visibility = [
         "//hw_services/sbr:__subpackages__",
@@ -75,9 +75,8 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
-# XXX: Unclear how to use these vs. the C++ generated code?
 nanopb_proto_library(
-    # XXX: Should change to use different suffixes
+    # TODO(#145): Should change to use different suffixes
     name = "lis3mdl_nanopb",
     deps = [":lis3mdl_proto"],
 )

--- a/hw_drivers/lis3mdl/BUILD
+++ b/hw_drivers/lis3mdl/BUILD
@@ -1,0 +1,129 @@
+load("@build_stack_rules_proto//rules:proto_compile.bzl", "proto_compile")
+load("@build_stack_rules_proto//rules/cc:proto_cc_library.bzl", "proto_cc_library")
+load("@com_google_emboss//:build_defs.bzl", "emboss_cc_library")
+load("@pigweed//pw_build:pigweed.bzl", "pw_cc_test")
+load(
+    "@pigweed//pw_protobuf_compiler:pw_proto_library.bzl",
+    "nanopb_proto_library",
+    "nanopb_rpc_proto_library",
+)
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//bzl:cc.bzl", "cc_library", "cc_test")
+load("//bzl:py.bzl", "proto_py_library")
+
+package(default_visibility = ["//visibility:private"])
+
+emboss_cc_library(
+    name = "lis3mdl_emb",
+    srcs = ["lis3mdl.emb"],
+    # XXX: Required for cross-compilation, investigate more
+    enable_enum_traits = False,
+    visibility = [
+        "//hw_services/sbr:__subpackages__",
+    ],
+)
+
+cc_library(
+    name = "lis3mdl",
+    srcs = ["lis3mdl.cc"],
+    hdrs = ["lis3mdl.h"],
+    visibility = [
+        "//hw_services/sbr:__subpackages__",
+    ],
+    deps = [
+        ":lis3mdl_emb",
+        ":lis3mdl_nanopb",
+        "@pigweed//pw_i2c:register_device",
+    ],
+)
+
+pw_cc_test(
+    name = "lis3mdl_pw_test",
+    srcs = ["lis3mdl_pw_test.cc"],
+    deps = [
+        ":lis3mdl",
+        ":lis3mdl_emb",
+        ":lis3mdl_nanopb",
+        "@pigweed//pw_bytes",
+        "@pigweed//pw_i2c:address",
+        "@pigweed//pw_i2c:device",
+        "@pigweed//pw_i2c:initiator_mock",
+        "@pigweed//pw_i2c:register_device",
+        "@pigweed//pw_result",
+        "@pigweed//pw_unit_test",
+    ],
+)
+
+cc_test(
+    name = "lis3mdl_test",
+    srcs = ["lis3mdl_test.cc"],
+    deps = [
+        ":lis3mdl",
+        ":lis3mdl_emb",
+        ":lis3mdl_nanopb",
+        "//testing:catch_main",
+        "@pigweed//pw_bytes",
+        "@pigweed//pw_i2c:address",
+        "@pigweed//pw_i2c:initiator_mock",
+        "@pigweed//pw_result",
+    ],
+)
+
+proto_library(
+    name = "lis3mdl_proto",
+    srcs = ["lis3mdl.proto"],
+    visibility = ["//visibility:public"],
+)
+
+# XXX: Unclear how to use these vs. the C++ generated code?
+nanopb_proto_library(
+    # XXX: Should change to use different suffixes
+    name = "lis3mdl_nanopb",
+    deps = [":lis3mdl_proto"],
+)
+
+nanopb_rpc_proto_library(
+    name = "lis3mdl_nanopb_rpc",
+    nanopb_proto_library_deps = [":lis3mdl_nanopb"],
+    deps = [":lis3mdl_proto"],
+)
+
+proto_cc_library(
+    name = "lis3mdl_cc_library",
+    srcs = ["lis3mdl.pb.cc"],
+    hdrs = ["lis3mdl.pb.h"],
+    visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:protobuf"],
+)
+
+proto_compile(
+    name = "lis3mdl_cpp_compile",
+    outputs = [
+        "lis3mdl.pb.cc",
+        "lis3mdl.pb.h",
+    ],
+    plugins = ["@build_stack_rules_proto//plugin/builtin:cpp"],
+    proto = "lis3mdl_proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_compile(
+    name = "lis3mdl_python_compile",
+    outputs = [
+        "lis3mdl_pb2.py",
+        "lis3mdl_pb2.pyi",
+    ],
+    plugins = [
+        "@build_stack_rules_proto//plugin/builtin:pyi",
+        "@build_stack_rules_proto//plugin/builtin:python",
+    ],
+    proto = "lis3mdl_proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_py_library(
+    name = "lis3mdl_py_library",
+    srcs = ["lis3mdl_pb2.py"],
+    visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:protobuf_python"],
+)

--- a/hw_drivers/lis3mdl/README.md
+++ b/hw_drivers/lis3mdl/README.md
@@ -1,0 +1,156 @@
+# LIS3MDL Magnetometer
+
+Reference:
+
+- https://www.pololu.com/file/0J1089/LIS3MDL.pdf
+- https://www.pololu.com/file/0J1090/LIS3MDL-AN4602.pdf
+
+Data style is a lot of 16-bit 2's complement.
+
+Register study:
+
+- (0x05 - 0x0A): Offset Management
+  - OUT = OUT_measured - OFFSET
+- (0x0F ): WHO_AM_I = (0x3D)
+- (0x20 - 0x24): CTRL_REG[1-5]
+  - Output Data Rate (Hz): (0.625, 1.25, 2.5, 5, 10, 20, 40, 80, 1000, 560,
+    300, 155)
+  - Operating Modes: (LOW_POWER, MEDIUM_PERFORMANCE, HIGH_PERFORMANCE,
+    ULTRA_HIGH_PERFORMANCE)
+    - x/y are independent from z
+  - Full Scale: (4, 8, 12, 16)
+  - Measurement Mode
+- (0x27 ): STATUS_REG
+- (0x28 - 0x2D): OUT_X/Y/Z for magnetometer
+- (0x2E - 0x2F): TEMP_OUT
+- (0x30 - 0x33): Interrupt Management
+
+Table 5: Noise in operating modes (average per axis)
+
+Table 8: Turn-on time
+
+| Operating mode         | RMS noise [mgauss] | Startup time [us] |
+| ---------------------- | ------------------ | ----------------- |
+| Ultra-high-performance | 3.5                | 6,650             |
+| High-performance       | 4.0                | 3,480             |
+| Medium-performance     | 4.6                | 1,910             |
+| Low-power              | 5.3                | 1,200             |
+
+- Not shown here
+  - TON (table 9)
+  - 2D table of ODR vs. Mode to current consumption
+
+State machine
+
+```
+STARTUP -> IDLE;
+SINGLE_MEASUREMENT -> IDLE (edge = single-measurement mode);
+(ANY) -> IDLE (edge = MD1 bit high);
+
+IDLE - 1 uA
+SINGLE_MEASUREMENT
+CONTINUOUS_MEASUREMENT
+```
+
+Startup sequence:
+
+- Power supply set
+- Power on, reset rising
+- Boot procedure from flash
+- Single Measure
+- Idle State
+- ? Unclear if DRDY is set?
+
+Commands to send for startup:
+
+1. CTRL_REG2(0x40) // full scale +/- 12 Hz
+2. CTRL_REG1(0xFC) // UHP on X/Y, ODR @ 80 Hz + temperature
+3. CTRL_REG4(0x0C) // UHP on Z
+4. CTRL_REG3(0x00) // CONTINUOUS_MEASUREMENT mode
+
+Reading
+
+- DRDY goes high when new data, and low when read
+  - via pin or STATUS_REG
+  - STATUS_REG also conveys whether we missed any samples
+
+Options:
+
+- Should set BDU (block data update) to avoid `_L and _H` section changing while
+  reading
+- FAST_READ discards the L values
+- BLE can change endianness of `_L and _H`
+
+Interrupts: We won't use now, but could be a neat low-power mechanism to detect
+a re-orientation
+
+Self-Test
+
+- This test is enabled by setting bit 0 to ‘1’ in the CTRL_REG1 (20h) register.
+- Keep device still during self-test
+
+```
+1. Write 1Ch to CTRL_REG1(20h)
+1. Write 40h to CTRL_REG2(21h)
+1. Wait 20ms
+1. Write 00h to CTRL_REG3(22h)
+
+Initialize Sensor, turn on sensor.
+FS=12Gauss, Continuous-Measurement mode, ODR = 80Hz
+
+
+Power up, wait 20ms for stable output
+
+Check ZYXDA in STATUS_REG (27h) – Data Ready Bit
+Read OUT_X_L(28h), OUT_X_H(29h), OUT_Y_L(2Ah), OUT_Y_H(2Bh), OUT_Z_L(2Ch), OUT_Z_H(2Dh) → Discard data
+- Reading OUTX/OUTY/OUTZ clears ZYXDA. Wait for the first sample.
+
+// Read the output registers after checking ZYXDA bit 5 times
+Read OUT_X_L(28h), OUT_X_H(29h): Store data in OUTX_NOST
+Read OUT_Y_L(2Ah), OUT_Y_H(2Bh): Store data in OUTY_NOST
+Read OUT_Z_L(2Ch), OUT_Z_H(2Dh): Store data in OUTZ_NOST
+// Average the stored data on each axis.
+
+Write 10h to CTRL_REG1(20h)
+// Enable Self Test
+Wait for 60 ms
+
+Check ZYXDA in STATUS_REG (27h) – Data Ready Bit
+// Reading OUTX/OUTY/OUTZ clears ZYXDA. Wait for the first sample.
+Read OUT_X_L(28h), OUT_X_H(29h), OUT_Y_L(2Ah), OUT_Y_H(2Bh), OUT_Z_L(2Ch), OUT_Z_H(2Dh) → Discard data
+
+
+// Read the output registers after checking ZYXDA bit * 5 times
+Read OUT_X_L(28h), OUT_X_H(29h): Store data in OUTX_ST
+Read OUT_Y_L(2Ah), OUT_Y_H(2Bh): Store data in OUTY_ST
+Read OUT_Z_L(2Ch), OUT_Z_H(2Dh): Store data in OUTZ_ST
+// Average the stored data on each axis.
+
+pass = compare min(st_?) <= out?_ST - out?_NOST <= max(st_?)
+
+Write 1Ch to CTRL_REG1(20h): Disable self-test
+Write 03h to CTRL_REG3(22h): Power-down mode
+```
+
+Self-test limits
+
+| Axis | MIN [gauss] | MAX [gauss] |
+| ---- | ----------- | ----------- |
+| X    | 1.0         | 3.0         |
+| Y    | 1.0         | 3.0         |
+| Z    | 0.1         | 3.0         |
+
+Temperature can be enabled/disabled, 0 = 25 C, 1/8 C per LSB, the magnetometer
+uses temperature compensation
+
+I2C address is `0b001_1x0`, x pased on SDO/SA1 pin
+
+Magnitude of Earth's magnetic field at surface ranges from 0.25 to 0.65 Gauss.
+I'm not sure if motors will render this less useful.
+
+Tests
+
+- [ ] self-test procedure
+- [ ] power motors near magnetometer and view output / characterize noise
+- [ ] Characterization. Sweep across resolutions, etc. and graph the output
+      stable and on lazy susan?

--- a/hw_drivers/lis3mdl/lis3mdl.cc
+++ b/hw_drivers/lis3mdl/lis3mdl.cc
@@ -2,14 +2,11 @@
 
 #include <expected>
 
-// XXX: Do I need these in my namespaces?
-using namespace std::chrono_literals;
-
 namespace hw_drivers {
 namespace lis3mdl {
 
 namespace {
-constexpr auto kI2cTimeout = 100ms;
+constexpr std::chrono::milliseconds kI2cTimeout{100};
 }
 
 DataView LIS3MDLData::GetView() {
@@ -70,7 +67,6 @@ SolveConfiguration(
     fast_output_data_rate = false;
   } else {
     fast_output_data_rate = true;
-    // XXX: What happens if we set exponent > 7 to our bitfield?
     exponent = 7;
     switch (operating_mode) {
       case OperatingMode::OPERATING_MODE_LOW_POWER:
@@ -89,7 +85,7 @@ SolveConfiguration(
   }
 
   // Scale Gauss
-  // XXX: Note that this selection is kinda the opposite of the rms noise
+  // Note that this selection is kinda the opposite of the rms noise
   auto desired_scale_gauss = desired_configuration.scale_gauss;
   uint32_t actual_scale_gauss;
   FullScaleSelection full_scale_choice;
@@ -167,22 +163,6 @@ SolveConfiguration(
       ((static_cast<int64_t>(view.out_y().Read()) * 1'000'000) / lsb_per_gauss);
   reading.magnetic_strength_z_ug =
       ((static_cast<int64_t>(view.out_z().Read()) * 1'000'000) / lsb_per_gauss);
-  // constexpr size_t kNumAxes = 3;
-  // XXX: Check fixed_size of array
-  // static_assert(kNumAxes == );
-  // int32_t magnetometer_readings[kNumAxes] = {
-  //   view.out_x().Read(),
-  //   view.out_y().Read(),
-  //   view.out_z().Read(),
-  // };
-  // XXX: Any fun new C++ iterable behavior?
-  // XXX need to get nanopb setup
-  // for (size_t i = 0; i < kNumAxes; ++i) {
-  //   reading.magnetic_strength_ug[i] = (
-  //       (static_cast<int64_t>(magnetometer_readings[i]) * 1'000'000)
-  //       / lsb_per_gauss);
-  // }
-  // reading.magnetic_strength_ug_count = kNumAxes;
   return reading;
 }
 

--- a/hw_drivers/lis3mdl/lis3mdl.cc
+++ b/hw_drivers/lis3mdl/lis3mdl.cc
@@ -1,0 +1,210 @@
+#include "hw_drivers/lis3mdl/lis3mdl.h"
+
+#include <expected>
+
+// XXX: Do I need these in my namespaces?
+using namespace std::chrono_literals;
+
+namespace hw_drivers {
+namespace lis3mdl {
+
+namespace {
+constexpr auto kI2cTimeout = 100ms;
+}
+
+DataView LIS3MDLData::GetView() {
+  return MakeDataView(bytes.data(), std::size(bytes));
+}
+
+std::expected<::hw_drivers_lis3mdl_LIS3MDLConfiguration, ConfigurationError>
+SolveConfiguration(
+    const ::hw_drivers_lis3mdl_LIS3MDLConfiguration& desired_configuration,
+    LIS3MDLControl* control) {
+  auto view = MakeControlView(control->bytes.data(), std::size(control->bytes));
+  // Constraints of our system:
+  // -
+  if (!(desired_configuration.has_temperature_enabled &&
+        desired_configuration.has_allowable_rms_noise_ug &&
+        desired_configuration.has_data_rate_millihz &&
+        desired_configuration.has_scale_gauss)) {
+    return std::unexpected(ConfigurationError::kInvalidConfig);
+  }
+
+  // RMS Noise and OperatingMode
+  auto desired_rms_noise_ug = desired_configuration.allowable_rms_noise_ug;
+  uint32_t actual_rms_noise_ug;
+  OperatingMode operating_mode;
+  if (desired_rms_noise_ug < 3'500) {
+    return std::unexpected(ConfigurationError::kUnsupportedConfig);
+  } else if (desired_rms_noise_ug < 4'000) {
+    actual_rms_noise_ug = 3'500;
+    operating_mode = OperatingMode::OPERATING_MODE_ULTRA_HIGH_PERFORMANCE;
+  } else if (desired_rms_noise_ug < 4'600) {
+    actual_rms_noise_ug = 4'000;
+    operating_mode = OperatingMode::OPERATING_MODE_HIGH_PERFORMANCE;
+  } else if (desired_rms_noise_ug < 5'300) {
+    actual_rms_noise_ug = 4'600;
+    operating_mode = OperatingMode::OPERATING_MODE_MEDIUM_PERFORMANCE;
+  } else {
+    actual_rms_noise_ug = 5'300;
+    operating_mode = OperatingMode::OPERATING_MODE_LOW_POWER;
+  }
+
+  // Date Rate Configuration
+  auto desired_data_rate_millihz = desired_configuration.data_rate_millihz;
+  constexpr uint32_t kBaseRate = 625;
+  // kBaseRate * 2 ^ exponent = frequency
+  // exponent = log2(frequency / kBaseRate)
+  // log2 for integer is just the position of the highest bit, which we get
+  // with std::bit-width(...) - 1
+  constexpr uint32_t kMaxExponent = 7;
+  uint32_t multiple_of_base = desired_data_rate_millihz / kBaseRate;
+  // 0 is invalid, we've got to have at least have 1 when we take log2
+  multiple_of_base = std::max(static_cast<uint32_t>(1), multiple_of_base);
+  uint32_t exponent = std::bit_width(multiple_of_base) - 1;
+  uint32_t actual_data_rate_millihz;
+  bool fast_output_data_rate;
+  if (exponent <= kMaxExponent) {
+    // kBaseRate * 2 ^ exponent = frequency (use bit-shifts to adjust)
+    actual_data_rate_millihz = kBaseRate << exponent;
+    fast_output_data_rate = false;
+  } else {
+    fast_output_data_rate = true;
+    // XXX: What happens if we set exponent > 7 to our bitfield?
+    exponent = 7;
+    switch (operating_mode) {
+      case OperatingMode::OPERATING_MODE_LOW_POWER:
+        actual_data_rate_millihz = 1'000'000;
+        break;
+      case OperatingMode::OPERATING_MODE_MEDIUM_PERFORMANCE:
+        actual_data_rate_millihz = 560'000;
+        break;
+      case OperatingMode::OPERATING_MODE_HIGH_PERFORMANCE:
+        actual_data_rate_millihz = 300'000;
+        break;
+      case OperatingMode::OPERATING_MODE_ULTRA_HIGH_PERFORMANCE:
+        actual_data_rate_millihz = 155'000;
+        break;
+    }
+  }
+
+  // Scale Gauss
+  // XXX: Note that this selection is kinda the opposite of the rms noise
+  auto desired_scale_gauss = desired_configuration.scale_gauss;
+  uint32_t actual_scale_gauss;
+  FullScaleSelection full_scale_choice;
+  if (desired_scale_gauss <= 4) {
+    actual_scale_gauss = 4;
+    full_scale_choice = FullScaleSelection::FULL_SCALE_SELECTION_4;
+  } else if (desired_scale_gauss <= 8) {
+    actual_scale_gauss = 8;
+    full_scale_choice = FullScaleSelection::FULL_SCALE_SELECTION_8;
+  } else if (desired_scale_gauss <= 12) {
+    actual_scale_gauss = 12;
+    full_scale_choice = FullScaleSelection::FULL_SCALE_SELECTION_12;
+  } else {
+    actual_scale_gauss = 16;
+    full_scale_choice = FullScaleSelection::FULL_SCALE_SELECTION_16;
+  }
+  ::hw_drivers_lis3mdl_LIS3MDLConfiguration result_configuration{
+      .has_temperature_enabled = true,
+      // Temperature
+      .temperature_enabled = desired_configuration.temperature_enabled,
+      .has_allowable_rms_noise_ug = true,
+      .allowable_rms_noise_ug = actual_rms_noise_ug,
+      .has_data_rate_millihz = true,
+      .data_rate_millihz = actual_data_rate_millihz,
+      .has_scale_gauss = true,
+      .scale_gauss = actual_scale_gauss,
+  };
+
+  // XXX: I could just do this elsewhere and send the information to write the
+  // output separately?
+  //
+  // Ensure full result before applying to control
+  view.temperature_enable().Write(result_configuration.temperature_enabled);
+  view.full_scale().Write(full_scale_choice);
+  view.xy_axis_operating_mode().Write(operating_mode);
+  view.z_axis_operating_mode().Write(operating_mode);
+  view.output_data_rate().Write(exponent);
+  view.fast_output_data_rate().Write(fast_output_data_rate);
+  // XXX: Set block update
+
+  return result_configuration;
+}
+
+// XXX: using lsb_per_gauss, since the scale isn't quite working out how I'd
+// expect / the LSBs are not mathing properly
+::hw_drivers_lis3mdl_LIS3MDLReading InterpretReading(uint32_t lsb_per_gauss,
+                                                     const LIS3MDLData& data) {
+  ::hw_drivers_lis3mdl_LIS3MDLReading reading;
+  auto view = MakeDataView(data.bytes.data(), std::size(data.bytes));
+
+  reading.has_data_fresh = true;
+  reading.data_fresh = view.zyxd_available().Read();
+  reading.has_data_overrun = true;
+  reading.data_overrun = view.zyx_overrun().Read();
+
+  // 0 = 25C
+  // LSB = 1/8 C = 1.25 dC = 125 mC
+  // We operate in mC then scale down to dC at the end.
+  constexpr int32_t kOffsetTemperatureMC = 25'000;
+  constexpr int32_t kTemperatureMCPerLSB = 125;
+  constexpr int32_t kMilliPerDeci = 100;
+  reading.has_temperature_dc = true;
+  reading.temperature_dc =
+      (((view.temperature_out().Read() * kTemperatureMCPerLSB) +
+        kOffsetTemperatureMC) /
+       kMilliPerDeci);
+
+  (void)lsb_per_gauss;
+  reading.has_magnetic_strength_x_ug = true;
+  reading.has_magnetic_strength_y_ug = true;
+  reading.has_magnetic_strength_z_ug = true;
+  reading.magnetic_strength_x_ug =
+      ((static_cast<int64_t>(view.out_x().Read()) * 1'000'000) / lsb_per_gauss);
+  reading.magnetic_strength_y_ug =
+      ((static_cast<int64_t>(view.out_y().Read()) * 1'000'000) / lsb_per_gauss);
+  reading.magnetic_strength_z_ug =
+      ((static_cast<int64_t>(view.out_z().Read()) * 1'000'000) / lsb_per_gauss);
+  // constexpr size_t kNumAxes = 3;
+  // XXX: Check fixed_size of array
+  // static_assert(kNumAxes == );
+  // int32_t magnetometer_readings[kNumAxes] = {
+  //   view.out_x().Read(),
+  //   view.out_y().Read(),
+  //   view.out_z().Read(),
+  // };
+  // XXX: Any fun new C++ iterable behavior?
+  // XXX need to get nanopb setup
+  // for (size_t i = 0; i < kNumAxes; ++i) {
+  //   reading.magnetic_strength_ug[i] = (
+  //       (static_cast<int64_t>(magnetometer_readings[i]) * 1'000'000)
+  //       / lsb_per_gauss);
+  // }
+  // reading.magnetic_strength_ug_count = kNumAxes;
+  return reading;
+}
+
+pw::Status ApplyControlToDevice(const LIS3MDLControl& control,
+                                pw::i2c::RegisterDevice* register_device) {
+  // XXX: Why won't std::size work?
+  std::array<std::byte, Control::MaxSizeInBytes() + 1> raw_buf = {std::byte{0}};
+  // XXX: Could I do something differently and avoid the extra buffer?
+  // - I could make a LIS3MDLControl that is "wrong" and the first value is the
+  // address?
+  auto buf = pw::as_writable_bytes(pw::span(raw_buf));
+  return register_device->WriteRegisters(
+      static_cast<uint8_t>(RegisterAddress::CONTROL), pw::span(control.bytes),
+      buf, kI2cTimeout);
+}
+
+pw::Status ReadFromDevice(LIS3MDLData* data,
+                          pw::i2c::RegisterDevice* register_device) {
+  return register_device->ReadRegisters(
+      static_cast<uint8_t>(RegisterAddress::DATA), pw::span(data->bytes),
+      kI2cTimeout);
+}
+
+}  // namespace lis3mdl
+}  // namespace hw_drivers

--- a/hw_drivers/lis3mdl/lis3mdl.emb
+++ b/hw_drivers/lis3mdl/lis3mdl.emb
@@ -1,0 +1,174 @@
+[$default byte_order: "LittleEndian"]
+[(cpp) namespace: "hw_drivers::lis3mdl"]
+
+
+enum RegisterAddress:
+  -- Structure names to their first address (we don't match everything as an
+  -- individual byte)
+
+  OFFSET = 0x05
+  WHO_AM_I = 0x0F
+  CONTROL = 0x20
+  DATA   = 0x27
+  INTERRUPT = 0x30
+
+enum OperatingMode:
+
+  OPERATING_MODE_LOW_POWER              = 0
+  OPERATING_MODE_MEDIUM_PERFORMANCE     = 1
+  OPERATING_MODE_HIGH_PERFORMANCE       = 2
+  OPERATING_MODE_ULTRA_HIGH_PERFORMANCE = 3
+
+
+enum ConversionMode:
+  CONVERSION_MODE_CONTINUOUS = 0
+  CONVERSION_MODE_SINGLE = 1
+  # There is no difference between A/B
+  CONVERSION_MODE_POWER_DOWN_A = 2
+  CONVERSION_MODE_POWER_DOWN_B = 3
+
+
+enum FullScaleSelection:
+  FULL_SCALE_SELECTION_4 = 0
+  FULL_SCALE_SELECTION_8 = 1
+  FULL_SCALE_SELECTION_12 = 2
+  FULL_SCALE_SELECTION_16 = 3
+
+struct Offset:
+  -- OUT = OUT_measured - OFFSET
+
+  0 [+2] Int out_x
+    -- X-axis data output. The value of the magnetic field.
+
+  2 [+2] Int out_y
+    -- Y-axis data output. The value of the magnetic field.
+
+  4 [+2] Int out_z
+    -- z-axis data output. The value of the magnetic field.
+
+# Not defining WHO_AM_I atm
+
+struct Control:
+  -- Control
+
+  0 [+1] bits:
+    # XXX: This can't be doc?
+    # CTRL_REG1
+
+    7 [+1] Flag temperature_enable
+      -- Temperature sensor enable. Default value: 0
+      -- (0: temperature sensor disabled; 1: temperature sensor enabled)
+
+    5 [+2] OperatingMode xy_axis_operating_mode
+
+    2 [+3] UInt output_data_rate
+      -- Output data rate selection. Default value: 0b100
+
+    1 [+1] Flag fast_output_data_rate
+      -- FAST_ODR enables data rates higher than 80 Hz (refer to Table 20).
+      -- Default value: 0
+      -- (0: Fast_ODR disabled; 1: FAST_ODR enabled)
+
+    0 [+1] Flag self_test_enable
+
+  1 [+1] bits:
+    # CTRL_REG2
+    # the not-set must be 0
+
+    5 [+2] FullScaleSelection full_scale
+      -- Refer to Table 25; Default: 0
+
+    3 [+1] Flag reboot
+      -- Reboot memory content. Default value: 0
+      -- (0: normal mode; 1: reboot memory content)
+
+    2 [+1] Flag soft_reset
+      -- Configuration registers and user register reset function.
+      -- (0: Default value; 1: Reset operation)
+
+  2 [+1] bits:
+    # CTRL_REG3
+
+    5 [+1] Flag low_power
+      -- Low-power mode configuration. Default value: 0
+      -- If this bit is ‘1’, DO[2:0] is set to 0.625 Hz and the system
+      -- performs, for each channel, the minimum number of averages. Once
+      -- the bit is set to ‘0’, the magnetic data rate is configured by
+      -- the DO bits in CTRL_REG1 (20h) register
+
+    2 [+1] Flag spi_serial_interface_mode_selection
+      -- SIM
+      -- Default value: 0
+      -- (0: 4-wire interface; 1: 3-wire interface).
+
+    0 [+2] ConversionMode conversion_mode
+
+  3 [+1] bits:
+    # CTRL_REG4
+
+    2 [+2] OperatingMode z_axis_operating_mode
+    1 [+1] Flag big_little_endian_selection
+      -- Big/Little Endian data selection. Default value: 0
+      -- (0: data LSb at lower address; 1: data MSb at lower address)
+
+  4 [+1] bits:
+    # CTRL_REG5
+
+    7 [+1] Flag fast_read
+      -- FAST READ allows reading the high part of DATA OUT only in order to
+      -- increase reading efficiency. Default value: 0
+      -- (0: FAST_READ disabled; 1: FAST_READ enabled)
+
+    6 [+1] Flag block_data_update
+      -- Block data update for magnetic data. Default value: 0
+      -- (0: continuous update; 1: output registers not updated until MSb and LSb have been read)
+
+
+struct Data:
+  # XXX: Is there a way to name these bits / the docs aren' too helpful?
+  0 [+1] bits:
+    7 [+1] Flag zyx_overrun
+      --  X-, Y- and Z-axis data overrun. Default value: 0
+      -- (0: no overrun has occurred; 1: a new set of data has overwritten the previous set)
+
+    6 [+1] Flag z_overrun
+      -- Z-axis data overrun. Default value: 0
+      -- (0: no overrun has occurred; 1: new data for the Z-axis has overwritten the previous data) 
+
+    5 [+1] Flag y_overrun
+      -- Y-axis data overrun. Default value: 0
+      -- (0: no overrun has occurred; 1: new data for the Y-axis has overwritten the previous data) 
+
+    4 [+1] Flag x_overrun
+      -- X-axis data overrun. Default value: 0
+      -- (0: no overrun has occurred; 1: new data for the X-axis has overwritten the previous data) 
+
+    3 [+1] Flag zyxd_available
+      --  X-, Y- and Z-axis new data available. Default value: 0
+      -- (0: a new set of data is not yet available; 1: a new set of data is available)
+
+    2 [+1] Flag zd_available
+      -- Z-axis new data available. Default value: 0
+      -- (0: new data for the Z-axis is not yet available; 1: new data for the Z-axis is available)
+
+    1 [+1] Flag yd_available
+      -- Y-axis new data available. Default value: 0
+      -- (0: new data for the Y-axis is not yet available; 1: new data for the Y-axis is available)
+
+    0 [+1] Flag xd_available
+      -- X-axis new data available. Default value: 0
+      -- (0: new data for the X-axis is not yet available; 1: new data for the X-axis is available)
+  
+  1 [+2] Int out_x
+    -- X-axis data output. The value of the magnetic field.
+
+  3 [+2] Int out_y
+    -- Y-axis data output. The value of the magnetic field.
+
+  5 [+2] Int out_z
+    -- z-axis data output. The value of the magnetic field.
+
+  7 [+2] Int temperature_out
+    -- Temperature sensor data
+
+# Ignoring INT

--- a/hw_drivers/lis3mdl/lis3mdl.emb
+++ b/hw_drivers/lis3mdl/lis3mdl.emb
@@ -52,7 +52,7 @@ struct Control:
   -- Control
 
   0 [+1] bits:
-    # XXX: This can't be doc?
+    # TODO(#144): This can't be doc?
     # CTRL_REG1
 
     7 [+1] Flag temperature_enable
@@ -125,7 +125,7 @@ struct Control:
 
 
 struct Data:
-  # XXX: Is there a way to name these bits / the docs aren' too helpful?
+  # TODO(#144): Is there a way to name these bits / the docs aren' too helpful?
   0 [+1] bits:
     7 [+1] Flag zyx_overrun
       --  X-, Y- and Z-axis data overrun. Default value: 0

--- a/hw_drivers/lis3mdl/lis3mdl.h
+++ b/hw_drivers/lis3mdl/lis3mdl.h
@@ -42,7 +42,6 @@ struct LIS3MDLControl {
   std::array<std::byte, Control::MaxSizeInBytes()> bytes{std::byte{0}};
 };
 
-
 // Functions to help handle the .proto and .emb objects as well as how to
 // interact with an actual i2c device.
 

--- a/hw_drivers/lis3mdl/lis3mdl.h
+++ b/hw_drivers/lis3mdl/lis3mdl.h
@@ -13,19 +13,15 @@
 namespace hw_drivers {
 namespace lis3mdl {
 
-constexpr pw::i2c::Address kHighAddress =
+static constexpr pw::i2c::Address kHighAddress =
     pw::i2c::Address::SevenBit<0b001'1110>();
-constexpr pw::i2c::Address kLowAddress =
+static constexpr pw::i2c::Address kLowAddress =
     pw::i2c::Address::SevenBit<0b001'1100>();
 
-// XXX: static or not?
-constexpr uint32_t kFullScale4LSBPerGauss = 6842;
-constexpr uint32_t kFullScale8LSBPerGauss = 3421;
-constexpr uint32_t kFullScale12LSBPerGauss = 2281;
-constexpr uint32_t kFullScale16LSBPerGauss = 1711;
-// XXX: Better way to define all of these various constants?
-// - this one is a bit annoying that the math doesn't quite work out.
-// - [ ] Test that magnitude remains same when changing full scale.
+static constexpr uint32_t kFullScale4LSBPerGauss = 6842;
+static constexpr uint32_t kFullScale8LSBPerGauss = 3421;
+static constexpr uint32_t kFullScale12LSBPerGauss = 2281;
+static constexpr uint32_t kFullScale16LSBPerGauss = 1711;
 
 enum class ConfigurationError {
   // Config is not valid, eg) missing expected parameters
@@ -34,62 +30,43 @@ enum class ConfigurationError {
   kUnsupportedConfig,
 };
 
+// Thin wrapper around lis3mdl.emb.h Data to own the data
 struct LIS3MDLData {
  public:
-  DataView GetView();
-
   std::array<std::byte, Data::MaxSizeInBytes()> bytes{std::byte{0}};
 };
 
+// Thin wrapper around lis3mdl.emb.h Control to own the data
 struct LIS3MDLControl {
  public:
   std::array<std::byte, Control::MaxSizeInBytes()> bytes{std::byte{0}};
 };
 
-// XXX: Move to util
-// template<size_t N, typename T>
-//
-// constant_integer<N> array_size( const std::array<T, N>& );
 
-// XXX:
-//
-// - function to compute reading based on settings and DataView
-// - maybe start math functions to handle these
-//
-// - [ ] may be try to detect bounding issue if not "locked"
-//   - I no longer know what ^ means
+// Functions to help handle the .proto and .emb objects as well as how to
+// interact with an actual i2c device.
 
-// XXX: Setup error result support ... -> std::expected!
-
-// XXX: This templating is annoying / requiring in .h
-// template <typename OtherStorage>
-// std::expected<LIS3MDLConfiguration, ConfigurationError>
-// SolveConfiguration(const LIS3MDLConfiguration& desired_configuration,
-//     GenericControlView<OtherStorage>* control);
-//  Switched to adding a wrapper class that owns the data to change it :shrug:
-
-// XXX: clang-format plz
-//
-// XXX: Support strict mode where desired must match actual (in a top-level
-// function)
-//
+// Given a desired_configuration, return the configuration available (or the
+// error for why finding a given configuration is not achievable). Also, if
+// successful, modify control to have the correct values that fit that
+// configuration.
 std::expected<::hw_drivers_lis3mdl_LIS3MDLConfiguration, ConfigurationError>
 SolveConfiguration(
     const ::hw_drivers_lis3mdl_LIS3MDLConfiguration& desired_configuration,
     LIS3MDLControl* control);
 
+// Create a LIS3MDLReading based on data from a device as well as an
+// understanding of the scale selected for the device.
 ::hw_drivers_lis3mdl_LIS3MDLReading InterpretReading(uint32_t lsb_per_gauss,
                                                      const LIS3MDLData& data);
 
-// XXX: return status, pass in i2c objects
+// Apply control to an i2c device
 pw::Status ApplyControlToDevice(const LIS3MDLControl& control,
                                 pw::i2c::RegisterDevice* register_device);
+
+// Read data from an i2c device
 pw::Status ReadFromDevice(LIS3MDLData* data,
                           pw::i2c::RegisterDevice* register_device);
-
-class LIS3MDL {
- public:
-};
 
 }  // namespace lis3mdl
 }  // namespace hw_drivers

--- a/hw_drivers/lis3mdl/lis3mdl.h
+++ b/hw_drivers/lis3mdl/lis3mdl.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <algorithm>
+#include <bit>
+#include <cstdint>
+#include <expected>
+
+#include "hw_drivers/lis3mdl/lis3mdl.emb.h"
+#include "hw_drivers/lis3mdl/lis3mdl.pb.h"
+#include "pw_i2c/address.h"
+#include "pw_i2c/register_device.h"
+
+namespace hw_drivers {
+namespace lis3mdl {
+
+constexpr pw::i2c::Address kHighAddress =
+    pw::i2c::Address::SevenBit<0b001'1110>();
+constexpr pw::i2c::Address kLowAddress =
+    pw::i2c::Address::SevenBit<0b001'1100>();
+
+// XXX: static or not?
+constexpr uint32_t kFullScale4LSBPerGauss = 6842;
+constexpr uint32_t kFullScale8LSBPerGauss = 3421;
+constexpr uint32_t kFullScale12LSBPerGauss = 2281;
+constexpr uint32_t kFullScale16LSBPerGauss = 1711;
+// XXX: Better way to define all of these various constants?
+// - this one is a bit annoying that the math doesn't quite work out.
+// - [ ] Test that magnitude remains same when changing full scale.
+
+enum class ConfigurationError {
+  // Config is not valid, eg) missing expected parameters
+  kInvalidConfig,
+  // Config is not supportable with the hardware
+  kUnsupportedConfig,
+};
+
+struct LIS3MDLData {
+ public:
+  DataView GetView();
+
+  std::array<std::byte, Data::MaxSizeInBytes()> bytes{std::byte{0}};
+};
+
+struct LIS3MDLControl {
+ public:
+  std::array<std::byte, Control::MaxSizeInBytes()> bytes{std::byte{0}};
+};
+
+// XXX: Move to util
+// template<size_t N, typename T>
+//
+// constant_integer<N> array_size( const std::array<T, N>& );
+
+// XXX:
+//
+// - function to compute reading based on settings and DataView
+// - maybe start math functions to handle these
+//
+// - [ ] may be try to detect bounding issue if not "locked"
+//   - I no longer know what ^ means
+
+// XXX: Setup error result support ... -> std::expected!
+
+// XXX: This templating is annoying / requiring in .h
+// template <typename OtherStorage>
+// std::expected<LIS3MDLConfiguration, ConfigurationError>
+// SolveConfiguration(const LIS3MDLConfiguration& desired_configuration,
+//     GenericControlView<OtherStorage>* control);
+//  Switched to adding a wrapper class that owns the data to change it :shrug:
+
+// XXX: clang-format plz
+//
+// XXX: Support strict mode where desired must match actual (in a top-level
+// function)
+//
+std::expected<::hw_drivers_lis3mdl_LIS3MDLConfiguration, ConfigurationError>
+SolveConfiguration(
+    const ::hw_drivers_lis3mdl_LIS3MDLConfiguration& desired_configuration,
+    LIS3MDLControl* control);
+
+::hw_drivers_lis3mdl_LIS3MDLReading InterpretReading(uint32_t lsb_per_gauss,
+                                                     const LIS3MDLData& data);
+
+// XXX: return status, pass in i2c objects
+pw::Status ApplyControlToDevice(const LIS3MDLControl& control,
+                                pw::i2c::RegisterDevice* register_device);
+pw::Status ReadFromDevice(LIS3MDLData* data,
+                          pw::i2c::RegisterDevice* register_device);
+
+class LIS3MDL {
+ public:
+};
+
+}  // namespace lis3mdl
+}  // namespace hw_drivers

--- a/hw_drivers/lis3mdl/lis3mdl.proto
+++ b/hw_drivers/lis3mdl/lis3mdl.proto
@@ -68,7 +68,6 @@ message LIS3MDLConfiguration {
   
   // Scale and resolution are intrinsically tied
   // Scales available are 4, 8, 12, 16 gauss range
-  // XXX: enum or not?
   optional uint32 scale_gauss = 4;
   
   // We could configure big/little endian, but we will allow the firmware to

--- a/hw_drivers/lis3mdl/lis3mdl.proto
+++ b/hw_drivers/lis3mdl/lis3mdl.proto
@@ -1,0 +1,115 @@
+// Information specific to LIS3MDL Magnetometer
+//
+// WIP - I am scratchpadding here / I'd like to avoid binding too many hardware
+// specifics here. Likely we'll leave most of the specifics in the C++ and
+// expose more of the human-decipherable output at a higher "imu" abstraction.
+//
+// Reference:
+// - https://www.pololu.com/file/0J1089/LIS3MDL.pdf
+// - https://www.pololu.com/file/0J1090/LIS3MDL-AN4602.pdf
+// - //hw_drivers/lis3mdl:README.md
+
+syntax = "proto3";
+
+package hw_drivers.lis3mdl;
+
+// XXX: add nanopb options back
+// import "nanopb.proto";
+
+
+// XXX: Should I define _INVALID at 0 and not tie to bit-mapping?
+// enum OperatingMode {
+//   OPERATING_MODE_LOW_POWER = 0;
+//   OPERATING_MODE_MEDIUM_PERFORMANCE = 1;
+//   OPERATING_MODE_HIGH_PERFORMANCE = 2;
+//   OPERATING_MODE_ULTRA_HIGH_PERFORMANCE = 3;
+// };
+
+// How do we want to configure this magnetometer.
+// 
+// XXX: Could change this to a desired configuration, and then the instrument
+// returns how it's actually able to be configured.
+//
+// We could also use power draw as a factor in selection.
+// Start-up time also factors in here.
+message LIS3MDLConfiguration {
+
+  // Whether to enable temperature reading
+  // XXX: Maybe just always enable it?
+  optional bool temperature_enabled = 1;
+  
+  // Defines the noise of the signal
+  // We won't allow different operating modes by axis, even though we could have
+  // a separate one for X/Y and Z
+  // There's a specific low power setting as well, we'll choose not to utilize
+  // that.
+  // optional OperatingMode operating_mode = 2;
+
+  // Perhaps we could define this as allowable_rms_noise in micro-Gauss
+  // [   0, 3500) INVALID
+  // [3500, 4000) UHP
+  // [4000, 4600) HP
+  // [4600, 5300) MP
+  // [5300, +inf) LP
+  // This determines OperatingMode
+  optional uint32 allowable_rms_noise_ug = 2;
+  
+  // Allowable Output Data Rate (mHz):
+  // (625, 1,250, 2,500, 5,000, 10,000, 20,000, 40,000, 80,000)
+  // Really just base 0.625 and a factor of 2 * 
+  // - then we add fast_odr and
+  // - LP: 1,000,000
+  // - MP:   560,000
+  // - HP:   300,000
+  // - UHP:  155,000 become valid
+  // data rate in milli-hertz
+  // XXX: Should I capitalize field names, eg) dB and mHz vs. MHz
+  optional uint32 data_rate_millihz = 3;
+  
+  // Scale and resolution are intrinsically tied
+  // Scales available are 4, 8, 12, 16 gauss range
+  // XXX: enum or not?
+  optional uint32 scale_gauss = 4;
+  
+  // We could configure big/little endian, but we will allow the firmware to
+  // determine the setting it would like to use.
+  
+  // We could also configure interrupt thresholds and behavior, but we don't
+  // support that.
+};
+
+message LIS3MDLCommands {
+  oneof cmd {
+    // XXX: I'm not sure what the difference is
+    bool reboot = 1;
+    bool soft_reset = 2;
+  };
+};
+
+message LIS3MDLReading {
+
+  // XXX: fixed repeated or individual fields?
+  // XXX: re-evaluate unit
+  // - experiment with unit libraries
+
+  // The magnetic strength in micro-Gauss
+  // XXX: Causes crash on assignment to a rpc result.
+  // repeated sint32 magnetic_strength_ug = 1;  // XXX [(nanopb).max_count = 3, (nanopb).fixed_count = true];
+  optional sint32 magnetic_strength_x_ug = 5;
+  optional sint32 magnetic_strength_y_ug = 6;
+  optional sint32 magnetic_strength_z_ug = 7;
+
+  // Temperature in tenths of a degree celcius (we get 1/8 C resolution).
+  optional sint32 temperature_dc = 2;
+
+  // Whether the data we're reading has been updated since our last reading
+  optional bool data_fresh = 3;
+  // Whether any data was overwritten since our last read
+  optional bool data_overrun = 4;
+};
+
+// For testing we may want to get a lot of readings
+// We could do a repeated LIS3MDLReading or a more efficient structure,
+// determine based on total number of reads ...
+//
+// [ ] Write tooling to describe how this thing'll work

--- a/hw_drivers/lis3mdl/lis3mdl.proto
+++ b/hw_drivers/lis3mdl/lis3mdl.proto
@@ -13,48 +13,26 @@ syntax = "proto3";
 
 package hw_drivers.lis3mdl;
 
-// XXX: add nanopb options back
+// TODO(#145): add nanopb options back
 // import "nanopb.proto";
 
 
-// XXX: Should I define _INVALID at 0 and not tie to bit-mapping?
-// enum OperatingMode {
-//   OPERATING_MODE_LOW_POWER = 0;
-//   OPERATING_MODE_MEDIUM_PERFORMANCE = 1;
-//   OPERATING_MODE_HIGH_PERFORMANCE = 2;
-//   OPERATING_MODE_ULTRA_HIGH_PERFORMANCE = 3;
-// };
-
 // How do we want to configure this magnetometer.
 // 
-// XXX: Could change this to a desired configuration, and then the instrument
-// returns how it's actually able to be configured.
-//
-// We could also use power draw as a factor in selection.
-// Start-up time also factors in here.
+// Possible future changes / adjustments:
+// - We could also use power draw as a factor in selection.
+// - Start-up time also factors in here.
 message LIS3MDLConfiguration {
 
   // Whether to enable temperature reading
-  // XXX: Maybe just always enable it?
+  // TODO(#148): Maybe just always enable it?
   optional bool temperature_enabled = 1;
   
-  // Defines the noise of the signal
-  // We won't allow different operating modes by axis, even though we could have
-  // a separate one for X/Y and Z
-  // There's a specific low power setting as well, we'll choose not to utilize
-  // that.
-  // optional OperatingMode operating_mode = 2;
-
-  // Perhaps we could define this as allowable_rms_noise in micro-Gauss
-  // [   0, 3500) INVALID
-  // [3500, 4000) UHP
-  // [4000, 4600) HP
-  // [4600, 5300) MP
-  // [5300, +inf) LP
-  // This determines OperatingMode
+  // Define allowable_rms_noise in micro-Gauss
   optional uint32 allowable_rms_noise_ug = 2;
   
-  // Allowable Output Data Rate (mHz):
+  // Allowable Output Data Rate (milli-Hz) for the magnetometer, see this table
+  // for a rough set of possibilities.
   // (625, 1,250, 2,500, 5,000, 10,000, 20,000, 40,000, 80,000)
   // Really just base 0.625 and a factor of 2 * 
   // - then we add fast_odr and
@@ -63,37 +41,18 @@ message LIS3MDLConfiguration {
   // - HP:   300,000
   // - UHP:  155,000 become valid
   // data rate in milli-hertz
-  // XXX: Should I capitalize field names, eg) dB and mHz vs. MHz
   optional uint32 data_rate_millihz = 3;
   
   // Scale and resolution are intrinsically tied
   // Scales available are 4, 8, 12, 16 gauss range
   optional uint32 scale_gauss = 4;
-  
-  // We could configure big/little endian, but we will allow the firmware to
-  // determine the setting it would like to use.
-  
-  // We could also configure interrupt thresholds and behavior, but we don't
-  // support that.
 };
 
-message LIS3MDLCommands {
-  oneof cmd {
-    // XXX: I'm not sure what the difference is
-    bool reboot = 1;
-    bool soft_reset = 2;
-  };
-};
 
 message LIS3MDLReading {
-
-  // XXX: fixed repeated or individual fields?
-  // XXX: re-evaluate unit
-  // - experiment with unit libraries
-
   // The magnetic strength in micro-Gauss
-  // XXX: Causes crash on assignment to a rpc result.
-  // repeated sint32 magnetic_strength_ug = 1;  // XXX [(nanopb).max_count = 3, (nanopb).fixed_count = true];
+  // TODO(#145): allow nanopb options
+  // repeated sint32 magnetic_strength_ug = 1 [(nanopb).max_count = 3, (nanopb).fixed_count = true];
   optional sint32 magnetic_strength_x_ug = 5;
   optional sint32 magnetic_strength_y_ug = 6;
   optional sint32 magnetic_strength_z_ug = 7;
@@ -103,6 +62,7 @@ message LIS3MDLReading {
 
   // Whether the data we're reading has been updated since our last reading
   optional bool data_fresh = 3;
+
   // Whether any data was overwritten since our last read
   optional bool data_overrun = 4;
 };

--- a/hw_drivers/lis3mdl/lis3mdl_pw_test.cc
+++ b/hw_drivers/lis3mdl/lis3mdl_pw_test.cc
@@ -1,0 +1,105 @@
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "hw_drivers/lis3mdl/lis3mdl.emb.h"
+#include "hw_drivers/lis3mdl/lis3mdl.h"
+#include "hw_drivers/lis3mdl/lis3mdl.pb.h"
+#include "pw_bytes/array.h"
+#include "pw_bytes/bit.h"
+#include "pw_i2c/address.h"
+#include "pw_i2c/initiator_mock.h"
+#include "pw_i2c/register_device.h"
+#include "pw_log/log.h"
+#include "pw_result/result.h"
+#include "pw_unit_test/framework.h"
+
+using namespace std::chrono_literals;
+
+namespace hw_drivers {
+namespace lis3mdl {
+
+namespace {
+
+// XXX: How to prevent bifurcation of pw_cc_test and cc_test?
+TEST(I2CTestSuite, I2CTransactions) {
+  constexpr pw::i2c::Address kAddress = pw::i2c::Address::SevenBit<0x01>();
+  constexpr auto kExpectedWrite = pw::bytes::Array<1, 2, 3, 4, 5, 6>();
+  constexpr auto kJustReg = pw::bytes::Array<1>();
+  constexpr auto kMockRead =
+      pw::bytes::Array<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>();
+  constexpr auto kControlWrite =
+      pw::bytes::Array<static_cast<uint8_t>(RegisterAddress::CONTROL),  // 0x20
+                       0xFC,  // 0b1111'1100,
+                       0x00, 0x00, 0x0C, 0x00>();
+  constexpr auto kDataRead = pw::bytes::Array<0, 0, 0, 0, 0, 0, 0, 0, 0>();
+  constexpr auto kDataReg =
+      pw::bytes::Array<static_cast<uint8_t>(RegisterAddress::DATA)>();
+  auto expected_transactions = pw::i2c::MakeExpectedTransactionArray({
+      pw::i2c::WriteTransaction(pw::OkStatus(), kAddress, kExpectedWrite, 1ms),
+      pw::i2c::Transaction(pw::OkStatus(), kAddress, kJustReg, kMockRead, 1ms),
+      pw::i2c::WriteTransaction(pw::OkStatus(), kAddress, kControlWrite, 1ms),
+      pw::i2c::Transaction(pw::OkStatus(), kAddress, kDataReg, kDataRead, 1ms),
+  });
+  pw::i2c::MockInitiator initiator(expected_transactions);
+  pw::i2c::RegisterDevice reg_device(initiator, kAddress, cpp20::endian::little,
+                                     pw::i2c::RegisterAddressSize::k1Byte);
+  pw::ConstByteSpan kRegWrite = pw::bytes::Array<2, 3, 4, 5, 6>();
+  std::array<std::byte, 12> raw_buf = {std::byte{0}};
+  auto buf = pw::as_writable_bytes(pw::span(raw_buf));
+  auto status = reg_device.WriteRegisters(
+      kAddress.GetSevenBit() /*register_address*/, kRegWrite, buf, 1ms);
+  // pw::ConstByteSpan kActualWrite = pw::bytes::Array<1, 2, 3>();
+  // pw::Status status = initiator.WriteFor(kAddress, kActualWrite, 1ms);
+  EXPECT_EQ(status, pw::OkStatus());
+  status = reg_device.ReadRegisters(kAddress.GetSevenBit(), buf, 1ms);
+  EXPECT_EQ(status, pw::OkStatus());
+  EXPECT_EQ(raw_buf, kMockRead);
+
+  // XXX: new section?
+  LIS3MDLControl control;
+  ::hw_drivers_lis3mdl_LIS3MDLConfiguration configuration{
+      .has_temperature_enabled = true,
+      // Temperature
+      .temperature_enabled = true,
+      .has_allowable_rms_noise_ug = true,
+      .allowable_rms_noise_ug = 3'500,
+      .has_data_rate_millihz = true,
+      .data_rate_millihz = 80'000,
+      .has_scale_gauss = true,
+      .scale_gauss = 4,
+  };
+  // XXX: Make Constant
+
+  auto result = SolveConfiguration(configuration, &control);
+  EXPECT_TRUE(result.has_value());
+  // Ensuring we are configuring exactly as desired
+  // auto actual_config = result.value();
+  // XXX: EXPECT_EQ(actual_config, configuration);
+  // XXX: Do I need + 1?
+  pw::StringBuffer<sizeof(control.bytes.data()) * 2 + 2> sb;
+  sb << "0x";
+  // XXX: Maybe should show as opposite?
+  for (const auto c : control.bytes) {
+    sb << std::format("{:#x}", static_cast<uint8_t>(c));
+  }
+  std::cout << "Control Bytes: " << sb.c_str() << std::endl;
+  // XXX: How to show LOG in test?
+  PW_LOG_INFO("Control bytes: %s", sb.c_str());
+
+  status = ApplyControlToDevice(control, &reg_device);
+  EXPECT_EQ(status, pw::OkStatus());
+
+  LIS3MDLData data;
+  status = ReadFromDevice(&data, &reg_device);
+  EXPECT_EQ(status, pw::OkStatus());
+
+  // XXX: This is a fairly annoying check, it doesn't say what's wrong
+  EXPECT_EQ(initiator.Finalize(), pw::OkStatus());
+}
+
+}  // namespace
+
+}  // namespace lis3mdl
+}  // namespace hw_drivers

--- a/hw_drivers/lis3mdl/lis3mdl_pw_test.cc
+++ b/hw_drivers/lis3mdl/lis3mdl_pw_test.cc
@@ -15,7 +15,6 @@
 #include "pw_result/result.h"
 #include "pw_unit_test/framework.h"
 
-
 namespace hw_drivers {
 namespace lis3mdl {
 
@@ -39,10 +38,14 @@ TEST(I2CTestSuite, I2CTransactions) {
   constexpr auto kDataReg =
       pw::bytes::Array<static_cast<uint8_t>(RegisterAddress::DATA)>();
   auto expected_transactions = pw::i2c::MakeExpectedTransactionArray({
-      pw::i2c::WriteTransaction(pw::OkStatus(), kAddress, kExpectedWrite, kI2cTimeout),
-      pw::i2c::Transaction(pw::OkStatus(), kAddress, kJustReg, kMockRead, kI2cTimeout),
-      pw::i2c::WriteTransaction(pw::OkStatus(), kAddress, kControlWrite, kI2cTimeout),
-      pw::i2c::Transaction(pw::OkStatus(), kAddress, kDataReg, kDataRead, kI2cTimeout),
+      pw::i2c::WriteTransaction(pw::OkStatus(), kAddress, kExpectedWrite,
+                                kI2cTimeout),
+      pw::i2c::Transaction(pw::OkStatus(), kAddress, kJustReg, kMockRead,
+                           kI2cTimeout),
+      pw::i2c::WriteTransaction(pw::OkStatus(), kAddress, kControlWrite,
+                                kI2cTimeout),
+      pw::i2c::Transaction(pw::OkStatus(), kAddress, kDataReg, kDataRead,
+                           kI2cTimeout),
   });
   pw::i2c::MockInitiator initiator(expected_transactions);
   pw::i2c::RegisterDevice reg_device(initiator, kAddress, cpp20::endian::little,
@@ -53,7 +56,8 @@ TEST(I2CTestSuite, I2CTransactions) {
   auto status = reg_device.WriteRegisters(
       kAddress.GetSevenBit() /*register_address*/, kRegWrite, buf, kI2cTimeout);
   // pw::ConstByteSpan kActualWrite = pw::bytes::Array<1, 2, 3>();
-  // pw::Status status = initiator.WriteFor(kAddress, kActualWrite, kI2cTimeout);
+  // pw::Status status = initiator.WriteFor(kAddress, kActualWrite,
+  // kI2cTimeout);
   EXPECT_EQ(status, pw::OkStatus());
   status = reg_device.ReadRegisters(kAddress.GetSevenBit(), buf, kI2cTimeout);
   EXPECT_EQ(status, pw::OkStatus());

--- a/hw_drivers/lis3mdl/lis3mdl_pw_test.cc
+++ b/hw_drivers/lis3mdl/lis3mdl_pw_test.cc
@@ -24,7 +24,7 @@ using namespace std::chrono_literals;
 
 constexpr auto kI2cTimeout = 100ms;
 
-// XXX: How to prevent bifurcation of pw_cc_test and cc_test?
+// TODO(#147): How to prevent bifurcation of pw_cc_test and cc_test?
 TEST(I2CTestSuite, I2CTransactions) {
   constexpr pw::i2c::Address kAddress = pw::i2c::Address::SevenBit<0x01>();
   constexpr auto kExpectedWrite = pw::bytes::Array<1, 2, 3, 4, 5, 6>();
@@ -34,7 +34,7 @@ TEST(I2CTestSuite, I2CTransactions) {
   constexpr auto kControlWrite =
       pw::bytes::Array<static_cast<uint8_t>(RegisterAddress::CONTROL),  // 0x20
                        0xFC,  // 0b1111'1100,
-                       0x00, 0x00, 0x0C, 0x00>();
+                       0x00, 0x00, 0x0C, 0x40>();
   constexpr auto kDataRead = pw::bytes::Array<0, 0, 0, 0, 0, 0, 0, 0, 0>();
   constexpr auto kDataReg =
       pw::bytes::Array<static_cast<uint8_t>(RegisterAddress::DATA)>();
@@ -59,9 +59,8 @@ TEST(I2CTestSuite, I2CTransactions) {
   EXPECT_EQ(status, pw::OkStatus());
   EXPECT_EQ(raw_buf, kMockRead);
 
-  // XXX: new section?
   LIS3MDLControl control;
-  ::hw_drivers_lis3mdl_LIS3MDLConfiguration configuration{
+  const ::hw_drivers_lis3mdl_LIS3MDLConfiguration configuration{
       .has_temperature_enabled = true,
       // Temperature
       .temperature_enabled = true,
@@ -72,22 +71,18 @@ TEST(I2CTestSuite, I2CTransactions) {
       .has_scale_gauss = true,
       .scale_gauss = 4,
   };
-  // XXX: Make Constant
 
   auto result = SolveConfiguration(configuration, &control);
   EXPECT_TRUE(result.has_value());
-  // Ensuring we are configuring exactly as desired
-  // auto actual_config = result.value();
-  // XXX: EXPECT_EQ(actual_config, configuration);
-  // XXX: Do I need + 1?
-  pw::StringBuffer<sizeof(control.bytes.data()) * 2 + 2> sb;
-  sb << "0x";
-  // XXX: Maybe should show as opposite?
+
+  // COULD: Make this a utility?
+  pw::StringBuffer<sizeof(control.bytes.data()) * 3 + 3> sb;
+  sb << "0x ";
   for (const auto c : control.bytes) {
-    sb << std::format("{:#x}", static_cast<uint8_t>(c));
+    sb << std::format("{:02X} ", static_cast<uint8_t>(c));
   }
   std::cout << "Control Bytes: " << sb.c_str() << std::endl;
-  // XXX: How to show LOG in test?
+  // TODO(#147): How to show LOG in test?
   PW_LOG_INFO("Control bytes: %s", sb.c_str());
 
   status = ApplyControlToDevice(control, &reg_device);
@@ -97,7 +92,7 @@ TEST(I2CTestSuite, I2CTransactions) {
   status = ReadFromDevice(&data, &reg_device);
   EXPECT_EQ(status, pw::OkStatus());
 
-  // XXX: This is a fairly annoying check, it doesn't say what's wrong
+  // NOTE: This is a fairly annoying check, it doesn't say what's wrong
   EXPECT_EQ(initiator.Finalize(), pw::OkStatus());
 }
 

--- a/hw_drivers/lis3mdl/lis3mdl_test.cc
+++ b/hw_drivers/lis3mdl/lis3mdl_test.cc
@@ -33,11 +33,8 @@ TEST_CASE("emboss and calculations are correct") {
   CHECK(buf[0] & 0x80);
 }
 
-// XXX: probably have to use nanopb syntax?
 TEST_CASE("SolveConfiguration") {
   ::hw_drivers_lis3mdl_LIS3MDLConfiguration configuration;
-  // XXX: Better naming schema to denote differences
-  // XXX: Analysis on size and run-time cost
   LIS3MDLControl control;
   auto control_view =
       MakeControlView(control.bytes.data(), std::size(control.bytes));
@@ -60,7 +57,6 @@ TEST_CASE("SolveConfiguration") {
   result = SolveConfiguration(configuration, &control);
   REQUIRE(result.has_value());
   auto actual_config = result.value();
-  // XXX: Better protobuf comparison
   REQUIRE(actual_config.has_temperature_enabled);
   CHECK(!actual_config.temperature_enabled);
   CHECK(!control_view.temperature_enable().Read());
@@ -71,17 +67,16 @@ TEST_CASE("SolveConfiguration") {
 }
 
 TEST_CASE("Read Data") {
-  // XXX: Max or Intrinsic?
-  static_assert(Data::MaxSizeInBytes() == 9);
-  static_assert(Data::IntrinsicSizeInBytes() == 9);
 
   LIS3MDLData d;
   auto view = MakeDataView(d.bytes.data(), std::size(d.bytes));
-  // XXX: Why aren't these equal / why is sizeof d.bytes.data() 8?
+  static_assert(Data::MaxSizeInBytes() == 9);
+  static_assert(Data::IntrinsicSizeInBytes() == 9);
   CHECK(d.bytes.size() == 9);
   CHECK(std::size(d.bytes) == 9);
-  // CHECK(sizeof(d.bytes.data()) == d.bytes.size());
+  // TODO(#144): Why aren't these equal / why is sizeof d.bytes.data() 8?
   // CHECK(sizeof(d.bytes.data()) == 9);
+  // CHECK(sizeof(d.bytes.data()) == d.bytes.size());
 
   // Check that reading uninitialized doesn't crash
   auto reading = InterpretReading(kFullScale4LSBPerGauss, d);
@@ -107,7 +102,6 @@ TEST_CASE("Read Data") {
   view.temperature_out().Write(0);
   reading = InterpretReading(kFullScale4LSBPerGauss, d);
   CHECK(reading.temperature_dc == 250);
-  // XXX: Check more
 
   view.out_x().Write(-100);
   view.out_y().Write(0);

--- a/hw_drivers/lis3mdl/lis3mdl_test.cc
+++ b/hw_drivers/lis3mdl/lis3mdl_test.cc
@@ -67,7 +67,6 @@ TEST_CASE("SolveConfiguration") {
 }
 
 TEST_CASE("Read Data") {
-
   LIS3MDLData d;
   auto view = MakeDataView(d.bytes.data(), std::size(d.bytes));
   static_assert(Data::MaxSizeInBytes() == 9);

--- a/hw_drivers/lis3mdl/lis3mdl_test.cc
+++ b/hw_drivers/lis3mdl/lis3mdl_test.cc
@@ -1,0 +1,130 @@
+#include "hw_drivers/lis3mdl/lis3mdl.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <vector>
+
+#include "hw_drivers/lis3mdl/lis3mdl.emb.h"
+#include "hw_drivers/lis3mdl/lis3mdl.pb.h"
+
+namespace hw_drivers {
+namespace lis3mdl {
+
+namespace {
+
+TEST_CASE("offset") {
+  uint8_t buf[Offset::MaxSizeInBytes()];
+
+  auto offset_view = MakeOffsetView(buf, std::size(buf));
+  offset_view.out_x().Write(0x1234);
+
+  CHECK(offset_view.out_x().Read() == 0x1234);
+  CHECK(buf[0] == 0x34);
+  CHECK(buf[1] == 0x12);
+}
+
+TEST_CASE("emboss and calculations are correct") {
+  uint8_t buf[Control::MaxSizeInBytes()];
+
+  auto control_view = MakeControlView(buf, std::size(buf));
+  control_view.temperature_enable().Write(true);
+
+  CHECK(control_view.temperature_enable().Read());
+  CHECK(buf[0] & 0x80);
+}
+
+// XXX: probably have to use nanopb syntax?
+TEST_CASE("SolveConfiguration") {
+  ::hw_drivers_lis3mdl_LIS3MDLConfiguration configuration;
+  // XXX: Better naming schema to denote differences
+  // XXX: Analysis on size and run-time cost
+  LIS3MDLControl control;
+  auto control_view =
+      MakeControlView(control.bytes.data(), std::size(control.bytes));
+  auto result = SolveConfiguration(configuration, &control);
+  REQUIRE(!result.has_value());
+  CHECK(result.error() == ConfigurationError::kInvalidConfig);
+
+  configuration = ::hw_drivers_lis3mdl_LIS3MDLConfiguration{
+      .has_temperature_enabled = true,
+      // Temperature
+      .temperature_enabled = false,
+      .has_allowable_rms_noise_ug = true,
+      .allowable_rms_noise_ug = 3'500,
+      .has_data_rate_millihz = true,
+      .data_rate_millihz = 80'000,
+      .has_scale_gauss = true,
+      .scale_gauss = 4,
+  };
+
+  result = SolveConfiguration(configuration, &control);
+  REQUIRE(result.has_value());
+  auto actual_config = result.value();
+  // XXX: Better protobuf comparison
+  REQUIRE(actual_config.has_temperature_enabled);
+  CHECK(!actual_config.temperature_enabled);
+  CHECK(!control_view.temperature_enable().Read());
+
+  // Test Plan:
+  // - rms noise coverage
+  // - check math on frequency decision / can I break it?
+}
+
+TEST_CASE("Read Data") {
+  // XXX: Max or Intrinsic?
+  static_assert(Data::MaxSizeInBytes() == 9);
+  static_assert(Data::IntrinsicSizeInBytes() == 9);
+
+  LIS3MDLData d;
+  auto view = MakeDataView(d.bytes.data(), std::size(d.bytes));
+  // XXX: Why aren't these equal / why is sizeof d.bytes.data() 8?
+  CHECK(d.bytes.size() == 9);
+  CHECK(std::size(d.bytes) == 9);
+  // CHECK(sizeof(d.bytes.data()) == d.bytes.size());
+  // CHECK(sizeof(d.bytes.data()) == 9);
+
+  // Check that reading uninitialized doesn't crash
+  auto reading = InterpretReading(kFullScale4LSBPerGauss, d);
+
+  // Check simple available / overrun behavior
+  view.zyxd_available().Write(1);
+  view.zyx_overrun().Write(1);
+  reading = InterpretReading(kFullScale4LSBPerGauss, d);
+  CHECK(reading.data_fresh);
+  CHECK(reading.data_overrun);
+
+  view.zyx_overrun().Write(0);
+  reading = InterpretReading(kFullScale4LSBPerGauss, d);
+  CHECK(reading.data_fresh);
+  CHECK(!reading.data_overrun);
+
+  view.zyxd_available().Write(0);
+  reading = InterpretReading(kFullScale4LSBPerGauss, d);
+  CHECK(!reading.data_fresh);
+  CHECK(!reading.data_overrun);
+
+  // Check Temperature
+  view.temperature_out().Write(0);
+  reading = InterpretReading(kFullScale4LSBPerGauss, d);
+  CHECK(reading.temperature_dc == 250);
+  // XXX: Check more
+
+  view.out_x().Write(-100);
+  view.out_y().Write(0);
+  view.out_z().Write(200);
+  reading = InterpretReading(kFullScale4LSBPerGauss, d);
+  CHECK(reading.magnetic_strength_x_ug == -14'615);
+  CHECK(reading.magnetic_strength_y_ug == 0);
+  CHECK(reading.magnetic_strength_z_ug == 29'231);
+
+  // Changing scale changes the behavior (eye-balled around 4x)
+  reading = InterpretReading(kFullScale16LSBPerGauss, d);
+  CHECK(reading.magnetic_strength_x_ug == -58'445);
+  CHECK(reading.magnetic_strength_y_ug == 0);
+  CHECK(reading.magnetic_strength_z_ug == 116'890);
+}
+
+}  // namespace
+
+}  // namespace lis3mdl
+}  // namespace hw_drivers


### PR DESCRIPTION
- Use [emboss](https://github.com/google/emboss) to define the register map for the LIS3MDL.
- Define proto interfaces to describe how we'd use this device / magnetometers in general.
- Setup a focused test as well as a `pw_test` in order to confirm some of the behavior for pw::i2c.
- Takes a lot of notes and possible changes in the future

Documents copied here for convenience:
- [LIS3MDL-AN4602.pdf](https://github.com/user-attachments/files/17693949/LIS3MDL-AN4602.pdf)
- [LIS3MDL.pdf](https://github.com/user-attachments/files/17693950/LIS3MDL.pdf)

Followups:
- #144 
- #145 
- #147 
- #148 
- #149