### PR TITLE
Configure warnings to error in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
-# Nothing now, but could filterwarnings, etc.
+filterwarnings =
+    error
 
 # No conftest.py needed as bazel is doing most of the heavy lifting for us


### PR DESCRIPTION
Configure warnings to error in pytest: https://docs.pytest.org/en/stable/how-to/capture-warnings.html#controlling-warnings