### PR TITLE
Miscellaneous improvements to graph usage, paths, etc

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2292,7 +2292,7 @@
     "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
         "bzlTransitiveDigest": "MnNArHHY8j8NDVbZuG3K3RqZcPVAM/4yMTGq0VScRm0=",
-        "usagesDigest": "DZsQo09Ud7EjhWHnt9FooxaI2Hu84u619i83zv8/LYA=",
+        "usagesDigest": "Rg9SYpgmPLgLajVIvIIeX2m3KYZzIlrImRQcdsRr5t8=",
         "recordedFileInputs": {
           "@@pigweed~//pw_env_setup/py/pw_env_setup/virtualenv_setup/upstream_requirements_windows_lock.txt": "4367c7d4cc4a1c2d6a136edace02581066f1c9ead10937685dde568d1061189f",
           "@@pigweed~//pw_env_setup/py/pw_env_setup/virtualenv_setup/upstream_requirements_linux_lock.txt": "ce8b16e007309a610c37eec908b75451733ae5efb9c14ec7e6f04557b81d621e",

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -28,3 +28,15 @@ py_binary(
         "@pip//tabulate",
     ],
 )
+
+py_library(
+    name = "path_utils",
+    srcs = ["path_utils.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_test(
+    name = "path_utils_test",
+    srcs = ["path_utils_test.py"],
+    deps = [":path_utils"],
+)

--- a/utils/bep_reader.py
+++ b/utils/bep_reader.py
@@ -17,7 +17,6 @@ Example:
 
 import collections
 import datetime
-import io
 import sys
 from typing import BinaryIO
 

--- a/utils/bep_reader.py
+++ b/utils/bep_reader.py
@@ -17,7 +17,9 @@ Example:
 
 import collections
 import datetime
+import io
 import sys
+from typing import BinaryIO
 
 import tabulate
 
@@ -25,15 +27,13 @@ from third_party.bazel.proto import build_event_stream_pb2
 from third_party.delimited_protobuf import delimited_protobuf
 
 
-def main() -> None:
-    msgs = []
+def get_label_to_runtime(buf: BinaryIO) -> dict[str, datetime.timedelta]:
     label_to_runtime: dict[str, list[datetime.timedelta]] = (
         collections.defaultdict(list)
     )
     while msg := delimited_protobuf.read_delimited(
-        sys.stdin.buffer, build_event_stream_pb2.BuildEvent
+        buf, build_event_stream_pb2.BuildEvent
     ):
-        msgs.append(msg)
         msg_id = msg.id.WhichOneof("id")
         if msg_id == "test_result":
             # Only register succesful tests
@@ -50,6 +50,12 @@ def main() -> None:
         for runtime in runtimes:
             total_runtime += runtime
         label_to_avg_runtime[label] = total_runtime / len(runtimes)
+    return label_to_avg_runtime
+
+
+def main() -> None:
+    buf = sys.stdin.buffer
+    label_to_avg_runtime = get_label_to_runtime(buf)
     table = sorted(label_to_avg_runtime.items(), key=lambda kv: -kv[1])
     print(tabulate.tabulate(table, headers=["Label", "dt"]))
 

--- a/utils/graph_algorithms_test.py
+++ b/utils/graph_algorithms_test.py
@@ -48,7 +48,7 @@ class TestGroupProbability(unittest.TestCase):
             2: p2,
             1: p1,
             8: p3 * node_probability[8],
-            9: node_probability[9]
+            9: node_probability[9],
         }
         group_probability = graph_algorithms.compute_group_probability(
             graph=g, node_probability=node_probability

--- a/utils/graph_algorithms_test.py
+++ b/utils/graph_algorithms_test.py
@@ -15,8 +15,10 @@ class TestGroupProbability(unittest.TestCase):
         g.add_edge(2, 4)
         g.add_node(5)
         g.add_edge(6, 7)
+        g.add_edge(3, 9)
+        g.add_edge(4, 9)
         node_probability = {
-            1: 0.1,
+            1: 0.6,
             2: 0.2,
             3: 0.3,
             4: 0.4,
@@ -25,14 +27,18 @@ class TestGroupProbability(unittest.TestCase):
             6: 0.3,
             # Intentionally leaving 7 empty
             8: 0.4,
+            9: 0.5,
         }
         # each should be itself times the group probability of its children
-        p2 = node_probability[2] * node_probability[3] * node_probability[4]
-        p1 = node_probability[1] * p2
+        p3 = node_probability[3] * node_probability[9]
+        p4 = node_probability[4] * node_probability[9]
+        # Shared descendant
+        p2 = node_probability[2] * (p3 * p4 / node_probability[9])
+        p1 = p2 * node_probability[1]
         expected_group_probability = {
             # Leaves
-            3: node_probability[3],
-            4: node_probability[4],
+            3: p3,
+            4: p4,
             5: node_probability[5],
             # Unspecified becomes 1
             7: 1.0,
@@ -41,19 +47,13 @@ class TestGroupProbability(unittest.TestCase):
             # each should be itself times the group probability of its children
             2: p2,
             1: p1,
-            8: node_probability[3] * node_probability[8],
+            8: p3 * node_probability[8],
+            9: node_probability[9]
         }
         group_probability = graph_algorithms.compute_group_probability(
             graph=g, node_probability=node_probability
         )
         self.assertEqual(group_probability, expected_group_probability)
-
-    def test_cycle(self):
-        g = networkx.DiGraph()
-        g.add_edge(1, 2)
-        g.add_edge(2, 1)
-        with self.assertRaisesRegex(KeyError, "1"):
-            graph_algorithms.compute_group_probability(g, {})
 
 
 class TestGroupDurations(unittest.TestCase):
@@ -66,6 +66,9 @@ class TestGroupDurations(unittest.TestCase):
         g.add_edge(2, 4)
         g.add_node(5)
         g.add_edge(6, 7)
+        # Common ancestor (2)
+        g.add_edge(3, 9)
+        g.add_edge(4, 9)
         node_duration = {
             1: 1,
             2: 2,
@@ -75,10 +78,13 @@ class TestGroupDurations(unittest.TestCase):
             # Leaving 6 empty
             7: 0.1,
             8: 8,
+            # Leaving 9 empty
         }
         d2 = node_duration[1] + node_duration[2]
         d3 = node_duration[3] + node_duration[8] + d2
         d4 = 0.0 + d2
+        # Common ancestor d2
+        d9 = d4 + d3 - d2
 
         expected_group_duration = {
             # Roots
@@ -93,6 +99,7 @@ class TestGroupDurations(unittest.TestCase):
             2: d2,
             3: d3,
             4: d4,
+            9: d9,
         }
         group_duration = graph_algorithms.compute_group_duration(
             graph=g, node_duration_s=node_duration
@@ -103,5 +110,4 @@ class TestGroupDurations(unittest.TestCase):
         g = networkx.DiGraph()
         g.add_edge(1, 2)
         g.add_edge(2, 1)
-        with self.assertRaisesRegex(KeyError, "1"):
-            graph_algorithms.compute_group_duration(g, {})
+        self.assertIsNotNone(networkx.find_cycle(g))

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -1,4 +1,3 @@
 import pathlib
 
-
 REPO_DIR = pathlib.Path(__name__).parent.parent

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -1,5 +1,4 @@
 import pathlib
 
 
-# XXX: Check
 REPO_DIR = pathlib.Path(__name__).parent.parent

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -1,0 +1,5 @@
+import pathlib
+
+
+# XXX: Check
+REPO_DIR = pathlib.Path(__name__).parent.parent

--- a/utils/path_utils_test.py
+++ b/utils/path_utils_test.py
@@ -1,4 +1,3 @@
-import pathlib
 import unittest
 
 # Module Under Test

--- a/utils/path_utils_test.py
+++ b/utils/path_utils_test.py
@@ -1,0 +1,12 @@
+import pathlib
+import unittest
+
+# Module Under Test
+from utils import path_utils
+
+
+class TestPathUtils(unittest.TestCase):
+    def test_repo_dir(self) -> None:
+        # Let's check that we can see ourselves
+        self.assertTrue((path_utils.REPO_DIR /
+                         'utils/path_utils_test.py').exists())

--- a/utils/path_utils_test.py
+++ b/utils/path_utils_test.py
@@ -8,5 +8,6 @@ from utils import path_utils
 class TestPathUtils(unittest.TestCase):
     def test_repo_dir(self) -> None:
         # Let's check that we can see ourselves
-        self.assertTrue((path_utils.REPO_DIR /
-                         'utils/path_utils_test.py').exists())
+        self.assertTrue(
+            (path_utils.REPO_DIR / "utils/path_utils_test.py").exists()
+        )


### PR DESCRIPTION
### Description

- Make `bep_reader` importable
- The graph algorithms actually need all descendants/ancestors, not just the
  immediate parent/child. Imagine the case where your uncle is also your parent
  is also your grandparent, while troublesome in a family, definitely a
  possibility in a graph. We wouldn't want to count that contribution twice.
  So, we'll remove our fun graph traversal.
- It was also helpful to specify a mechanism to reference the repo path.
