### PR TITLE
Reproduce gazelle py_binary conflict

### DIFF
--- a/apps/example_bokeh.py
+++ b/apps/example_bokeh.py
@@ -1,0 +1,11 @@
+import networkx
+
+
+def main() -> None:
+    # Create a NetworkX graph
+    # G = networkx.fast_gnp_random_graph(100, 0.1, directed=True)
+    G = networkx.gnr_graph(100, 0.1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Run `bazel run //:gazelle apps` and get this diff:

```diff
diff --git a/apps/BUILD b/apps/BUILD
index 2ced4c6..f09b191 100644
--- a/apps/BUILD
+++ b/apps/BUILD
@@ -11,7 +11,7 @@ filegroup(

 py_binary(
     name = "bazel_parser",
-    srcs = ["bazel_parser.py"],
+    srcs = ["example_bokeh.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["//tools:bazel_utils"],
+    deps = ["@pip//networkx"],
 )
```

> If python_generation_mode is set to file, then instead of one py_binary target per module, Gazelle will create one py_binary target for each file with such a line, and the name of the target will match the name of the script.

Note that `BUILD` does have:

```
# gazelle:python_generation_mode file
```