### PR TITLE
Add Coverage Back

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -88,8 +88,7 @@ jobs:
           df -h
       - name: Coverage
         run: |
-          # Avoid enormous tests; can find them with: `bazel query 'attr(size, enormous, //...)'`
-          bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_size_filters=-enormous --output_groups=-mypy
+          bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_tag_filters=-skip-large-tests --output_groups=-mypy
       - name: Check Disk Usage
         if: always()
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,10 +35,6 @@ jobs:
           # - Should we add instrumentation_filter to .bazelrc to reduce
           # analysis cache thrashing?
           # Could leave the above to buildbuddy ...
-      - name: Coverage
-        run: |
-          # Avoid enormous tests; can find them with: `bazel query 'attr(size, enormous, //...)'`
-          bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_size_filters=-enormous --output_groups=-mypy
       - name: Check Disk Usage
         if: always()
         run: |
@@ -52,6 +48,10 @@ jobs:
           sudo dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -nr | head
           df . -h
           sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
+      - name: Coverage
+        run: |
+          # Avoid enormous tests; can find them with: `bazel query 'attr(size, enormous, //...)'`
+          bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_size_filters=-enormous --output_groups=-mypy
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
       - name: Coverage Report Generation

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,13 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - run: echo "The job was triggered by a ${{ github.event_name }} event, running on ${{ runner.os }}, ${{ github.ref }} @ ${{ github.repository }}."
-      - name: Check Disk Usage
-        if: always()
-        # echo "Disk usage by directory (sorted by size):"
-        # du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
-        # sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
-        run: |
-          df -h
       - uses: actions/checkout@v4
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -25,9 +18,6 @@ jobs:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
           tool-cache: false
-          
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
           # Data on sizes from this run on 2025-04-25:
           # https://github.com/michael-christen/toolbox/actions/runs/14666765877/job/41163363493
           # 8.21 GB
@@ -43,10 +33,6 @@ jobs:
           docker-images: true
           # 4.0 GB
           swap-storage: true
-      - name: Check Disk Usage
-        if: always()
-        run: |
-          df -h
       - uses: ./.github/actions/bazel-setup
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -55,24 +41,12 @@ jobs:
           # Needed for clang-format / llvm_toolchain, otherwise libtinfo.so.5
           # is not found
           sudo apt-get install -y libncurses5
-      - name: Check Disk Usage
-        if: always()
-        run: |
-          df -h
       - name: Lint
         run: |
           ./lint.sh --mode check
-      - name: Check Disk Usage
-        if: always()
-        run: |
-          df -h
       - name: Build
         run: |
           bazel build //...
-      - name: Check Disk Usage
-        if: always()
-        run: |
-          df -h
       - name: Test
         run: |
           bazel test //... --output_groups=-mypy
@@ -82,17 +56,9 @@ jobs:
           # - Should we add instrumentation_filter to .bazelrc to reduce
           # analysis cache thrashing?
           # Could leave the above to buildbuddy ...
-      - name: Check Disk Usage
-        if: always()
-        run: |
-          df -h
       - name: Coverage
         run: |
           bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_tag_filters=-skip-large-tests --output_groups=-mypy
-      - name: Check Disk Usage
-        if: always()
-        run: |
-          df -h
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
       - name: Coverage Report Generation
@@ -124,4 +90,7 @@ jobs:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.dat
+      - name: Check Disk Usage
+        run: |
+          df -h
       - run: echo "Status is ${{ job.status }}."

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
           df -h
       - uses: actions/checkout@v4
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,29 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - run: echo "The job was triggered by a ${{ github.event_name }} event, running on ${{ runner.os }}, ${{ github.ref }} @ ${{ github.repository }}."
+      - name: Check Disk Usage
+        if: always()
+        run: |
+          echo "Checking disk usage..."
+          df -h
+          echo "Disk usage by directory (sorted by size):"
+          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
+          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - uses: actions/checkout@v4
+      - name: Check Disk Usage
+        if: always()
+        run: |
+          echo "Checking disk usage..."
+          df -h
+          echo "Disk usage by directory (sorted by size):"
+          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
+          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - uses: ./.github/actions/bazel-setup
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -20,12 +42,45 @@ jobs:
           # Needed for clang-format / llvm_toolchain, otherwise libtinfo.so.5
           # is not found
           sudo apt-get install -y libncurses5
+      - name: Check Disk Usage
+        if: always()
+        run: |
+          echo "Checking disk usage..."
+          df -h
+          echo "Disk usage by directory (sorted by size):"
+          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
+          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Lint
         run: |
           ./lint.sh --mode check
+      - name: Check Disk Usage
+        if: always()
+        run: |
+          echo "Checking disk usage..."
+          df -h
+          echo "Disk usage by directory (sorted by size):"
+          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
+          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Build
         run: |
           bazel build //...
+      - name: Check Disk Usage
+        if: always()
+        run: |
+          echo "Checking disk usage..."
+          df -h
+          echo "Disk usage by directory (sorted by size):"
+          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
+          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Test
         run: |
           bazel test //... --output_groups=-mypy
@@ -42,12 +97,10 @@ jobs:
           df -h
           echo "Disk usage by directory (sorted by size):"
           du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
-      - name: Check disk space
-        if: always()
-        run: |
-          sudo dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -nr | head
-          df . -h
           sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
+          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Coverage
         run: |
           # Avoid enormous tests; can find them with: `bazel query 'attr(size, enormous, //...)'`

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,19 @@ jobs:
         run: |
           # Avoid enormous tests; can find them with: `bazel query 'attr(size, enormous, //...)'`
           bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_size_filters=-enormous --output_groups=-mypy
+      - name: Check Disk Usage
+        if: always()
+        run: |
+          echo "Checking disk usage..."
+          df -h
+          echo "Disk usage by directory (sorted by size):"
+          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
+      - name: Check disk space
+        if: always()
+        run: |
+          sudo dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -nr | head
+          df . -h
+          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
       - name: Coverage Report Generation

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,41 +35,39 @@ jobs:
           # - Should we add instrumentation_filter to .bazelrc to reduce
           # analysis cache thrashing?
           # Could leave the above to buildbuddy ...
-      # Need to disable coverage for now
-      # TODO(#216): Restore coverage
-      # - name: Coverage
-      #   run: |
-      #     # Avoid enormous tests; can find them with: `bazel query 'attr(size, enormous, //...)'`
-      #     bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_size_filters=-enormous --output_groups=-mypy
-      # - name: Setup LCOV
-      #   uses: hrishikesh-kadam/setup-lcov@v1
-      # - name: Coverage Report Generation
-      #   run: |
-      #     # Generate baseline
-      #     bazel run tools:coverage_baseline -- --root_dir `pwd` > baseline_coverage.dat
-      #     # Remove external/ sources: https://manpages.debian.org/unstable/lcov/lcov.1.en.html
-      #     lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o most_coverage.dat
-      #     # Combine with baseline
-      #     lcov -a baseline_coverage.dat -a most_coverage.dat -o coverage.dat
-      #     # Show Table
-      #     lcov --list coverage.dat
-      #     # Generate HTML
-      #     genhtml --legend --highlight --branch-coverage --output genhtml coverage.dat
-      # # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts
-      # - name: Archive coverage.dat
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: code-coverage-report
-      #     path: coverage.dat
-      # - name: Archive genhtml
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: code-coverage-html
-      #     path: genhtml
-      # - name: Upload coverage report to Codecov
-      #   uses: codecov/codecov-action@v4.0.1
-      #   with:
-      #     verbose: true
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     files: coverage.dat
-      # - run: echo "Status is ${{ job.status }}."
+      - name: Coverage
+        run: |
+          # Avoid enormous tests; can find them with: `bazel query 'attr(size, enormous, //...)'`
+          bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_size_filters=-enormous --output_groups=-mypy
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
+      - name: Coverage Report Generation
+        run: |
+          # Generate baseline
+          bazel run tools:coverage_baseline -- --root_dir `pwd` > baseline_coverage.dat
+          # Remove external/ sources: https://manpages.debian.org/unstable/lcov/lcov.1.en.html
+          lcov --remove "$(bazel info output_path)/_coverage/_coverage_report.dat" 'external*' -o most_coverage.dat
+          # Combine with baseline
+          lcov -a baseline_coverage.dat -a most_coverage.dat -o coverage.dat
+          # Show Table
+          lcov --list coverage.dat
+          # Generate HTML
+          genhtml --legend --highlight --branch-coverage --output genhtml coverage.dat
+      # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts
+      - name: Archive coverage.dat
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: coverage.dat
+      - name: Archive genhtml
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-html
+          path: genhtml
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.dat
+      - run: echo "Status is ${{ job.status }}."

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,15 +13,11 @@ jobs:
       - run: echo "The job was triggered by a ${{ github.event_name }} event, running on ${{ runner.os }}, ${{ github.ref }} @ ${{ github.repository }}."
       - name: Check Disk Usage
         if: always()
+        # echo "Disk usage by directory (sorted by size):"
+        # du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
+        # sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
         run: |
-          echo "Checking disk usage..."
           df -h
-          echo "Disk usage by directory (sorted by size):"
-          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
-          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - uses: actions/checkout@v4
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -41,14 +37,7 @@ jobs:
       - name: Check Disk Usage
         if: always()
         run: |
-          echo "Checking disk usage..."
           df -h
-          echo "Disk usage by directory (sorted by size):"
-          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
-          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - uses: ./.github/actions/bazel-setup
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -60,42 +49,21 @@ jobs:
       - name: Check Disk Usage
         if: always()
         run: |
-          echo "Checking disk usage..."
           df -h
-          echo "Disk usage by directory (sorted by size):"
-          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
-          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Lint
         run: |
           ./lint.sh --mode check
       - name: Check Disk Usage
         if: always()
         run: |
-          echo "Checking disk usage..."
           df -h
-          echo "Disk usage by directory (sorted by size):"
-          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
-          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Build
         run: |
           bazel build //...
       - name: Check Disk Usage
         if: always()
         run: |
-          echo "Checking disk usage..."
           df -h
-          echo "Disk usage by directory (sorted by size):"
-          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
-          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Test
         run: |
           bazel test //... --output_groups=-mypy
@@ -108,18 +76,15 @@ jobs:
       - name: Check Disk Usage
         if: always()
         run: |
-          echo "Checking disk usage..."
           df -h
-          echo "Disk usage by directory (sorted by size):"
-          du -h / --max-depth=1 2>/dev/null | sort -hr | head -n 20
-          sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /home/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
-          sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - name: Coverage
         run: |
           # Avoid enormous tests; can find them with: `bazel query 'attr(size, enormous, //...)'`
           bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_size_filters=-enormous --output_groups=-mypy
+      - name: Check Disk Usage
+        if: always()
+        run: |
+          df -h
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
       - name: Coverage Report Generation

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,21 @@ jobs:
           sudo du /opt/ -hx -d 4 --threshold=1G | sort -hr | head
           sudo du /mnt/ -hx -d 4 --threshold=1G | sort -hr | head
       - uses: actions/checkout@v4
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Check Disk Usage
         if: always()
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,11 +28,20 @@ jobs:
           
           # all of these default to true, but feel free to set to
           # "false" if necessary for your workflow
+          # Data on sizes from this run on 2025-04-25:
+          # https://github.com/michael-christen/toolbox/actions/runs/14666765877/job/41163363493
+          # 8.21 GB
           android: true
+          # 1.6 GB
           dotnet: true
+          # 6.2 GB
           haskell: true
-          large-packages: true
+          # 4.9 GB
+          # But ... It takes about 120s to clean, so setting false
+          large-packages: false
+          # 2.5 GB
           docker-images: true
+          # 4.0 GB
           swap-storage: true
       - name: Check Disk Usage
         if: always()

--- a/.github/workflows/flakiness.yml
+++ b/.github/workflows/flakiness.yml
@@ -22,5 +22,5 @@ jobs:
         run: |
           # Run several times to identify flakiness, but avoid enormous tests
           # Can find them with: `bazel query 'attr(size, enormous, //...)'`
-          bazel test --runs_per_test_detects_flakes --runs_per_test=5 --test_tag_filters=-skip-flakiness -- //...
+          bazel test --runs_per_test_detects_flakes --runs_per_test=5 --test_tag_filters=-skip-large-tests -- //...
       - run: echo "Status is ${{ job.status }}."

--- a/BUILD
+++ b/BUILD
@@ -34,7 +34,7 @@ pip_compile(
         # Don't want to type-check requirements building
         "no-mypy",
         # Avoid in flake detection
-        "skip-flakiness",
+        "skip-large-tests",
     ],
 )
 

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -12,8 +12,8 @@ actions:
       # TODO(#209): Don't require installing this
       - run: 'sudo apt-get update && sudo apt-get install -y graphviz graphviz-dev'
       - run: 'bazel build //...'
-      - run: 'bazel test //...'
-      - run: 'bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_size_filters=-enormous'
+      - run: 'bazel test //... --output_groups=-mypy'
+      - run: 'bazel coverage //... --combined_report=lcov --instrument_test_targets --instrumentation_filter="^//" --test_tag_filters=-skip-large-tests --output_groups=-mypy'
     resource_requests:
       # The default 20GB was too small
       disk: 40GB


### PR DESCRIPTION
Remove the disabling of coverage from #215 , resolve #216

- Add a tool https://github.com/jlumbroso/free-disk-space to get an extra 23 GB on the runner at the cost of about 30-90s time per run (removing android library can be a fair chunk) ... note if I start building android, that may be an issue. Making a self-hosted runner may simplify a lot of this setup.
- re-enable coverage
- avoid tests with the tag "-skip-large-tests", rather than test_size_filter
- use `--output_groups=-mypy` to avoid mypy in coverage tests, etc. in buildbuddy and github