### PR TITLE
Move pygraphviz dep to panel, rely on experimental_requirement_cycles

### DIFF
--- a/tlbox/apps/bazel_parser/BUILD
+++ b/tlbox/apps/bazel_parser/BUILD
@@ -77,15 +77,13 @@ py_binary(
         ":parsing",
         ":refinement",
         "//tlbox/utils:bazel_utils",
-        "//tools:git_py_library",
-        "//tlbox/utils:git_utils",
         "//tlbox/utils:bep_reader",
+        "//tlbox/utils:git_utils",
+        "//tools:git_py_library",
         "@pip//click",
         "@pip//networkx",
         "@pip//pandas",
         "@pip//pydantic",
-        # TODO(#263): Should associate with networkx
-        "@pip//pygraphviz",  # keep
         "@pip//pyyaml",
     ],
 )


### PR DESCRIPTION
## Summary

- Moves `@pip//pygraphviz` from `cli` to `panel` where it's actually used (via `networkx.drawing.nx_agraph`)
- Removes the `# keep` directive — `experimental_requirement_cycles` in `MODULE.bazel` already groups `networkx` and `pygraphviz` together, so `@pip//networkx` carries `pygraphviz` automatically

Closes #263

## Test plan

CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)