### PR TITLE
Fix grpc_cc_library by adding grpc to root MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,6 +48,7 @@ bazel_dep(name = "emboss", repo_name = "com_google_emboss")
 bazel_dep(name = "freertos", version = "10.5.1.bcr.2")
 bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "gazelle_cc", version = "0.5.0")
+bazel_dep(name = "grpc", version = "1.74.1", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "hedron_compile_commands")
 bazel_dep(name = "nanopb", version = "0.4.9.1", repo_name = "com_github_nanopb_nanopb")
 bazel_dep(name = "pico-sdk", version = "2.0.0")
@@ -115,6 +116,10 @@ bazel_dep(name = "toolchains_llvm", version = "1.5.0")
 # - freertos
 # - gazelle: https://github.com/bazel-contrib/bazel-gazelle
 # - gazelle_cc: https://github.com/EngFlow/gazelle_cc
+# - grpc: https://registry.bazel.build/modules/grpc
+#   - repo_name = "com_github_grpc_grpc" to match what build_stack_rules_proto
+#     uses internally, so generated grpc_cc_library targets resolve from root
+#   - See https://github.com/michael-christen/toolbox/issues/40
 # - hedron_compile_commands
 # - nanopb
 # - pico-sdk

--- a/examples/basic/BUILD
+++ b/examples/basic/BUILD
@@ -1,4 +1,5 @@
 load("@build_stack_rules_proto//rules:proto_compile.bzl", "proto_compile")
+load("@build_stack_rules_proto//rules/cc:grpc_cc_library.bzl", "grpc_cc_library")
 load("@build_stack_rules_proto//rules/cc:proto_cc_library.bzl", "proto_cc_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//bzl:py.bzl", "grpc_py_library", "proto_py_library", "py_binary", "py_image", "py_test")
@@ -167,4 +168,16 @@ proto_py_library(
     srcs = ["hello_pb2.py"],
     visibility = ["//visibility:public"],
     deps = ["@com_google_protobuf//:protobuf_python"],
+)
+
+grpc_cc_library(
+    name = "hello_grpc_cc_library",
+    srcs = ["hello.grpc.pb.cc"],
+    hdrs = ["hello.grpc.pb.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":hello_cc_library",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_grpc_grpc//:grpc++_reflection",
+    ],
 )

--- a/gazelle_proto_config.yaml
+++ b/gazelle_proto_config.yaml
@@ -46,8 +46,7 @@ languages:
     rules:
       - proto_compile
       - proto_cc_library
-      # TODO(https://github.com/michael-christen/toolbox/issues/40): re-enable
-      # - grpc_cc_library
+      - grpc_cc_library
   - name: "python"
     plugins:
       - python


### PR DESCRIPTION
## Summary

- Adds `grpc` as an explicit `bazel_dep` in `MODULE.bazel` with `repo_name = "com_github_grpc_grpc"`, making `@com_github_grpc_grpc` visible from the root module
- Re-enables `grpc_cc_library` in `gazelle_proto_config.yaml` and removes the TODO
- Closes #40

## Root cause

`build_stack_rules_proto` declares `grpc` with `repo_name = "com_github_grpc_grpc"` internally, but bzlmod doesn't propagate `repo_name` aliases transitively to the root module. Gazelle-generated `grpc_cc_library` targets reference `@com_github_grpc_grpc`, which was invisible from the root, causing analysis failures.

The upb/C++20 compilation issues also mentioned in #40 are no longer present — they were fixed upstream in grpc 1.74.1.

## Test plan

- [x] `bazel build //examples/basic:hello_grpc_cc_library` succeeds
- [x] `bazel build //...` succeeds (all 291 targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)