### PR TITLE
Add expect_failure analysis test example (#259)

### DIFF
--- a/examples/basic/BUILD
+++ b/examples/basic/BUILD
@@ -153,7 +153,8 @@ py_test(
         ":server",
         "//examples/basic:hello_py_library",
     ],
-    # TODO(#259): How to expect_failure
+    # For analysis-time failures, see examples/bazel/my_rules_test.bzl (expect_failure=True).
+    # For pytest-level expected failures, use @pytest.mark.xfail on individual test methods.
 )
 
 grpc_py_library(

--- a/examples/bazel/my_rules.bzl
+++ b/examples/bazel/my_rules.bzl
@@ -10,6 +10,9 @@ FooInfo = provider(
 
 # ctx fields: https://bazel.build/rules/lib/builtins/ctx
 def _foo_binary_impl(ctx):
+    if not ctx.attr.username:
+        fail("username must not be empty")
+
     # Get toolchain specifics into the rule
     info = ctx.toolchains[":toolchain_type"].fooinfo
     out = ctx.actions.declare_file(ctx.label.name)

--- a/examples/bazel/my_rules_test.bzl
+++ b/examples/bazel/my_rules_test.bzl
@@ -13,11 +13,31 @@ def _foo_binary_test_impl(ctx):
 
 typ_foo_binary_test = analysistest.make(_foo_binary_test_impl)
 
+# expect_failure: verify that foo_binary fails at analysis time when username is empty.
+# analysistest.make(expect_failure=True) inverts the pass/fail logic — the test
+# passes only if the target under test fails at analysis time with the given message.
+def _foo_binary_empty_username_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(env, "username must not be empty")
+    return analysistest.end(env)
+
+typ_foo_binary_empty_username_test = analysistest.make(
+    _foo_binary_empty_username_test_impl,
+    expect_failure = True,
+)
+
 # Macro to setup the test
 def _test_contents():
     # Leave manual so this only gets built as dependency of the test, not :all
     foo_binary(name = "test_foo", username = "Bob", tags = ["manual"])
     typ_foo_binary_test(name = "foo_binary_test", target_under_test = ":test_foo", timeout = "short")
+
+    foo_binary(name = "test_foo_empty_username", username = "", tags = ["manual"])
+    typ_foo_binary_empty_username_test(
+        name = "foo_binary_empty_username_test",
+        target_under_test = ":test_foo_empty_username",
+        timeout = "short",
+    )
 
 def my_rules_test_suite(name):
     # Need to instantiate
@@ -27,5 +47,6 @@ def my_rules_test_suite(name):
         name = name,
         tests = [
             ":foo_binary_test",
+            ":foo_binary_empty_username_test",
         ],
     )


### PR DESCRIPTION
## Summary

- Adds `fail()` validation to `foo_binary` when `username` is empty
- Demonstrates `analysistest.make(expect_failure=True)` + `asserts.expect_failure()` in `my_rules_test.bzl`
- Replaces `TODO(#259)` comment in `examples/basic/BUILD` with a pointer to the example and a note on `@pytest.mark.xfail`

Closes #259.

## Notes

`analysistest(expect_failure=True)` covers analysis-time rule failures only. Compile-time C++ failures have no clean Bazel-native mechanism. Runtime C++ failures use Catch2's `REQUIRE_THROWS_AS` family.

## Test plan

- [x] `bazel test //examples/bazel:my_rules_test` passes (both `foo_binary_test` and `foo_binary_empty_username_test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)