### PR TITLE
Fix autoapi by enabling symlink traversal (sphinx-autoapi 3.7.0)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,9 @@ autoapi_type = "python"
 autoapi_template_dir = "_templates/autoapi"
 # https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_python_use_implicit_namespaces
 autoapi_python_use_implicit_namespaces = True
+# Bazel sandbox sources are symlinks; follow them to find Python files.
+# https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_follow_symlinks
+autoapi_follow_symlinks = True
 # https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_options
 autoapi_options = [
     "members",


### PR DESCRIPTION
sphinx-autoapi 3.7.0 introduced autoapi_follow_symlinks with a default
of False. Bazel sandboxes all source inputs as symlinks, so autoapi
stopped finding Python files and produced empty API docs.

https://claude.ai/code/session_01Bn39Pe4L2SSyeQ5M53nFwb