### PR TITLE
Fix sphinx autoapi by copying sandbox tree to dereference symlinks

### DIFF
--- a/tools/sphinx/sphinx_build_wrapper.py
+++ b/tools/sphinx/sphinx_build_wrapper.py
@@ -11,16 +11,18 @@ def main():
     # is provided via a directory symlink (or file symlinks) into bazel-out.
     # This causes two problems:
     #
-    # 1. MyST resolves relative .md links via os.path.realpath, giving bazel-out
-    #    paths. Sphinx's env.srcdir must match those paths for env.path2doc() to
-    #    convert them to docnames, or cross-file references break.
+    # 1. MyST resolves relative .md links via os.path.realpath, giving
+    # bazel-out paths. Sphinx's env.srcdir must match those paths for
+    # env.path2doc() to convert them to docnames, or cross-file references
+    # break.
     #
     # 2. autoapi writes .rst files to {srcdir}/autoapi. If srcdir is bazel-out,
-    #    that directory is read-only (completed build outputs).
+    # that directory is read-only (completed build outputs).
     #
     # Fix: when symlinks are detected, copy the entire sandbox tree (following
-    # symlinks) to a fresh tmpdir. With real files, realpath(file) == abspath(file),
-    # so MyST and sphinx agree on srcdir, and autoapi can write freely.
+    # symlinks) to a fresh tmpdir. With real files, realpath(file) ==
+    # abspath(file), so MyST and sphinx agree on srcdir, and autoapi can write
+    # freely.
     if len(sys.argv) >= 3:
         sandbox_srcdir = os.path.abspath(sys.argv[-2])
         needs_deref = False
@@ -43,7 +45,9 @@ def main():
                 dirs_exist_ok=True,
                 ignore_dangling_symlinks=True,
             )
-            real_srcdir = os.path.join(tmpdir, os.path.basename(sandbox_srcdir))
+            real_srcdir = os.path.join(
+                tmpdir, os.path.basename(sandbox_srcdir)
+            )
             outdir = sys.argv[-1]
             sys.argv = sys.argv[:-2] + [real_srcdir, outdir]
 


### PR DESCRIPTION
## Summary

- The wrapper introduced in #274 ran sphinx from the execroot srcdir (to fix MyST link resolution) while redirecting autoapi output to the writable sandbox — two different paths sphinx couldn't reconcile, so autoapi pages never appeared in the output
- #278 added `autoapi_follow_symlinks = True` but didn't address the root cause
- New approach: when symlinks are detected in the sandbox, copy the entire tree with symlinks dereferenced (`shutil.copytree(symlinks=False)`) before running sphinx. With real files, `realpath == abspath` everywhere, so MyST and autoapi both work correctly from a single consistent srcdir

## Test plan

- [x] `bazel build //docs` produces output with an `autoapi/` directory
- [x] `bazel run //docs:docs.view` shows API Reference section in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)