### PR TITLE
Add self-hosted Renovate workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchManagers": ["pip-compile"],
+      "groupName": "python dependencies",
+      "postUpgradeTasks": {
+        "commands": ["bazel run //:gazelle_python_manifest.update"],
+        "executionMode": "branch",
+        "fileFilters": ["gazelle_python.yaml"]
+      }
+    },
+    {
+      "matchManagers": ["bazel-module"],
+      "groupName": "bazel modules"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,28 @@
+name: Renovate
+run-name: Self-hosted Renovate dependency scan
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+
+jobs:
+  renovate:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: ./.github/actions/bazel-setup
+        with:
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v46.1.20
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # bazel-module manager needs this to run `bazel mod deps` and
+          # refresh MODULE.bazel.lock itself.
+          RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["bazelModDeps"]'
+          # postUpgradeTasks needs each runnable command explicitly allowed.
+          RENOVATE_ALLOWED_COMMANDS: '["^bazel run //:gazelle_python_manifest\\.update$"]'


### PR DESCRIPTION
## Summary
- Adds a self-hosted Renovate workflow (scheduled + workflow_dispatch) as an experiment to replace Dependabot's security-fix PRs, which were hand-editing `requirements_lock.txt` without regenerating hashes or the gazelle manifest.
- Groups updates per ecosystem (python / bazel modules / github actions) instead of one PR per dependency.
- Python group runs `bazel run //:gazelle_python_manifest.update` after lock regeneration via a `postUpgradeTasks` hook.
- Bazel modules group relies on Renovate's native `bazel-module` manager to refresh `MODULE.bazel.lock` via `bazel mod deps`.
- Uses the default `GITHUB_TOKEN` for now (not a PAT) — Renovate's own PRs won't auto-trigger `build-and-test.yml` as a result (GitHub suppresses workflow-triggered-by-GITHUB_TOKEN events); rely on manually closing/reopening the PR to kick CI in the meantime. A PAT for hands-off automation is a documented follow-up.

Relates to #237 (Configure Renovate for Automatic Dependency Management) — doesn't fully close it, since that issue's checklist also calls for replacing the monthly `upgrade-dependencies.yml`, which this PR intentionally leaves in place until Renovate is validated.

## Test plan
- [ ] Merge to register the `workflow_dispatch` trigger (required before `gh workflow run` can target it on any branch)
- [ ] Manually dispatch via `gh workflow run renovate.yml --ref renovate_experiment` (or a future branch) and inspect the first PRs it opens before trusting hash/lockfile regeneration
- [ ] Confirm `bazel-module` PRs correctly update `MODULE.bazel.lock`
- [ ] Confirm python PRs regenerate `requirements_lock.txt` hashes and `gazelle_python.yaml` together