### PR TITLE
Fix renovate.yml: run via npx instead of dockerized action

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,9 @@
   "pip-compile": {
     "managerFilePatterns": ["/(^|/)requirements_lock\\.txt$/"]
   },
+  "vulnerabilityAlerts": {
+    "groupName": "security updates"
+  },
   "packageRules": [
     {
       "matchManagers": ["pip-compile"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "pip_requirements": {
+    "enabled": false
+  },
+  "pip-compile": {
+    "managerFilePatterns": ["/(^|/)requirements_lock\\.txt$/"]
+  },
   "packageRules": [
     {
       "matchManagers": ["pip-compile"],

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,15 +35,9 @@ jobs:
         # that all shell out to `bazel`.
         run: npx --yes renovate@43.278.5
         env:
-          LOG_LEVEL: debug
           RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          # XXX: Renovate reads renovate.json from the default branch, not
-          # from whatever ref triggered workflow_dispatch. Point it at this
-          # branch so we can test config changes before merging to master.
-          # Remove once #362 lands.
-          RENOVATE_BASE_BRANCHES: '["update_renovate"]'
           # bazel-module manager needs this to run `bazel mod deps` and
           # refresh MODULE.bazel.lock itself.
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["bazelModDeps"]'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -30,6 +30,11 @@ jobs:
           RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # XXX: Renovate reads renovate.json from the default branch, not
+          # from whatever ref triggered workflow_dispatch. Point it at this
+          # branch so we can test config changes before merging to master.
+          # Remove once #362 lands.
+          RENOVATE_BASE_BRANCHES: '["update_renovate"]'
           # bazel-module manager needs this to run `bazel mod deps` and
           # refresh MODULE.bazel.lock itself.
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["bazelModDeps"]'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
         # this separate tool. Renovate's own docker image bundles it via
         # containerbase; running via bare npx does not.
         run: |
-          pip install --user hashin
+          pip install --user hashin==1.0.5
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Self-hosted Renovate
         # Run via npx directly rather than renovatebot/github-action: that

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,6 +35,7 @@ jobs:
         # that all shell out to `bazel`.
         run: npx --yes renovate@43.278.5
         env:
+          LOG_LEVEL: debug
           RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: ./.github/actions/bazel-setup
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
       - name: Self-hosted Renovate
         # Run via npx directly rather than renovatebot/github-action: that
         # action executes Renovate inside its own nested Docker container,

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,6 +19,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+      - name: Install hashin
+        # Renovate's pip hash-patching (used for vulnerability-alert fixes
+        # regardless of pip-compile/pip_requirements config) shells out to
+        # this separate tool. Renovate's own docker image bundles it via
+        # containerbase; running via bare npx does not.
+        run: |
+          pip install --user hashin
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Self-hosted Renovate
         # Run via npx directly rather than renovatebot/github-action: that
         # action executes Renovate inside its own nested Docker container,

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,9 +17,15 @@ jobs:
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v46.1.20
+        # Run via npx directly rather than renovatebot/github-action: that
+        # action executes Renovate inside its own nested Docker container,
+        # which can't see the bazel/bazelisk set up on the runner above -
+        # breaking the pip-compile, bazel-module, and postUpgradeTasks steps
+        # that all shell out to `bazel`.
+        run: npx --yes renovate@43.278.5
         env:
-          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # bazel-module manager needs this to run `bazel mod deps` and
           # refresh MODULE.bazel.lock itself.


### PR DESCRIPTION
## Summary
Follow-up to #361. First scheduled/dispatched run (https://github.com/michael-christen/toolbox/actions/runs/30019670145/job/89248792944) failed with `You must configure a GitHub token`.

Root cause was two-fold:
- `renovatebot/github-action` reads the token from a `with: token:` input, not a `RENOVATE_TOKEN` env var - ours was silently ignored.
- More importantly, that action runs Renovate inside its own nested Docker container, isolated from the runner host. That container can't see the `bazel`/`bazelisk` installed via the `bazel-setup` step earlier in the job, which would have broken the `pip-compile` manager's lock regeneration, the `bazel-module` manager's `bazel mod deps`, and the gazelle `postUpgradeTasks` hook even after fixing the token.

Switched to running `npx renovate` directly as a `run:` step so it shares the runner's PATH like everything else in the job.

## Test plan
- [ ] Dispatch `renovate.yml` again on this branch and confirm it gets past initialization
- [ ] Confirm it can actually invoke `bazel` for the python/bazel-module groups