### PR TITLE
Fix python dependency group: pip-compile manager can't parse our lock header

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,23 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "pip_requirements": {
-    "enabled": false
-  },
-  "pip-compile": {
-    "managerFilePatterns": ["/(^|/)requirements_lock\\.txt$/"]
-  },
   "vulnerabilityAlerts": {
     "groupName": "security updates"
   },
   "packageRules": [
     {
-      "matchManagers": ["pip-compile"],
+      "matchManagers": ["pip_requirements"],
       "groupName": "python dependencies",
       "postUpgradeTasks": {
-        "commands": ["bazel run //:gazelle_python_manifest.update"],
+        "commands": [
+          "bazel run //:requirements.update",
+          "bazel run //:gazelle_python_manifest.update"
+        ],
         "executionMode": "branch",
-        "fileFilters": ["gazelle_python.yaml"]
+        "fileFilters": ["requirements_lock.txt", "gazelle_python.yaml"]
       }
     },
     {

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,8 +31,8 @@ jobs:
         # Run via npx directly rather than renovatebot/github-action: that
         # action executes Renovate inside its own nested Docker container,
         # which can't see the bazel/bazelisk set up on the runner above -
-        # breaking the pip-compile, bazel-module, and postUpgradeTasks steps
-        # that all shell out to `bazel`.
+        # breaking the bazel-module and postUpgradeTasks steps that shell
+        # out to `bazel`.
         run: npx --yes renovate@43.278.5
         env:
           RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,4 +42,9 @@ jobs:
           # refresh MODULE.bazel.lock itself.
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["bazelModDeps"]'
           # postUpgradeTasks needs each runnable command explicitly allowed.
-          RENOVATE_ALLOWED_COMMANDS: '["^bazel run //:gazelle_python_manifest\\.update$"]'
+          # The pip_requirements group's postUpgradeTasks fully regenerates
+          # requirements_lock.txt (pip-compile manager can't be used here -
+          # it only recognizes headers whose command is literally
+          # "pip-compile" or "uv", and ours records the bazel-wrapped
+          # invocation instead) and syncs the gazelle manifest.
+          RENOVATE_ALLOWED_COMMANDS: '["^bazel run //:requirements\\.update$", "^bazel run //:gazelle_python_manifest\\.update$"]'


### PR DESCRIPTION
## Summary
Follow-up to #362. First real run on master ([30061507009](https://github.com/michael-christen/toolbox/actions/runs/30061507009)) showed `pip-compile` never appearing in Renovate's manager stats at all, despite `managerFilePatterns` being set correctly and confirmed read from master.

Root cause, found by reading Renovate's actual source (`lib/modules/manager/pip-compile/common.ts`): the manager only recognizes a lock file's header if the recorded command is literally `pip-compile` or `uv`. Our `requirements_lock.txt` header records `bazel run @@//:requirements` (rules_python's uv-via-bazel wrapper) - the command word `bazel` falls through to `commandType: 'custom'`, and the parser then misreads `run` and `@@//:requirements` as bogus source `.in` files that don't exist on disk. Extraction silently fails no matter how `managerFilePatterns` is tuned - this is a structural incompatibility with our lock file's header format, not a config bug.

Fix: revert to the `pip_requirements` manager (which does see the file, and whose `hashin`-based artifact updater now works after installing `hashin` in CI). Use it purely to detect what needs bumping, then let `postUpgradeTasks` run the authoritative `bazel run //:requirements.update` (the same command `upgrade-dependencies.yml` already uses) to fully regenerate the lock file - `hashin` only patches one line's hash and doesn't re-resolve the whole dependency graph, so this keeps the file fully consistent regardless of what `hashin` did on its own.

## Test plan
- [ ] Dispatch `renovate.yml` after merging and confirm `pip_requirements` shows up with a real depCount and no artifact errors
- [ ] Confirm `postUpgradeTasks` actually regenerates `requirements_lock.txt` hashes correctly and syncs `gazelle_python.yaml`
- [ ] Confirm the python dependency PRs stay grouped into one branch rather than reverting to one-per-dependency