### PR TITLE
Fix vulnerability-alert postUpgradeTasks, cap rules_rust, add dependencies label

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "prHourlyLimit": 10,
+  "labels": ["dependencies"],
   "vulnerabilityAlerts": {
-    "groupName": "security updates"
+    "groupName": "security updates",
+    "postUpgradeTasks": {
+      "commands": [
+        "bazel run //:requirements.update",
+        "bazel run //:gazelle_python_manifest.update"
+      ],
+      "executionMode": "branch",
+      "fileFilters": ["requirements_lock.txt", "gazelle_python.yaml"]
+    }
   },
   "packageRules": [
     {
@@ -21,6 +30,11 @@
     {
       "matchManagers": ["bazel-module"],
       "groupName": "bazel modules"
+    },
+    {
+      "matchManagers": ["bazel-module"],
+      "matchPackageNames": ["rules_rust"],
+      "allowedVersions": "<0.71.0"
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Summary
Three fixes surfaced from the last Renovate run ([30069502733](https://github.com/michael-christen/toolbox/actions/runs/30069502733), PRs #393-397):

1. **`postUpgradeTasks` wasn't firing for vulnerability-alert branches.** PRs #393 (tornado) and #394 (cryptography) updated `requirements_lock.txt` (via `hashin`'s single-line patch) but left `gazelle_python.yaml` completely untouched - its `integrity` field hashes the entire lock file's content, so if the lock file changed at all, that field must change too. Its absence is proof `bazel run //:requirements.update`/`gazelle_python_manifest.update` never ran for these branches. Likely cause: `vulnerabilityAlerts` force-merges over `packageRules` (documented: [renovatebot/renovate#15107](https://github.com/renovatebot/renovate/discussions/15107)), wiping the `postUpgradeTasks` the `pip_requirements` rule set. Declaring the same hook directly under `vulnerabilityAlerts` to test the fix.
2. **`rules_rust` needs a version cap.** Now that it's a plain `bazel_dep` (#392), Renovate immediately proposed bumping it to `0.71.3` as part of the `bazel-modules` group (PR #395) - walking straight back into the Pigweed transitive-lockfile incompatibility `0.70.0` was chosen specifically to avoid. Capped with `allowedVersions: "<0.71.0"`; remove once Pigweed's own `MODULE.bazel` ships a lockfile for its `crate_universe` declarations.
3. **Add the `dependencies` label** to all Renovate PRs (label already exists in the repo).

Also filed #398 for a separate, pre-existing, unrelated `bazel mod deps` failure surfaced by PR #396 (bumping `.bazelversion` to 8.7.0) - a `rules_jvm_external`/maven extension bug, nothing to do with `rules_rust`.

## Test plan
- [ ] Dispatch `renovate.yml` and confirm a fresh security-alert PR includes `gazelle_python.yaml` in its diff
- [ ] Confirm `rules_rust` no longer shows up as a pending bump in the bazel-modules group
- [ ] Confirm new PRs carry the `dependencies` label