### PR TITLE
Remove logger.debug("a") scaffolding from dependency_analysis

### DIFF
--- a/tlbox/apps/bazel_parser/repo_graph_data.py
+++ b/tlbox/apps/bazel_parser/repo_graph_data.py
@@ -246,17 +246,18 @@ class RepoGraphData:
 def dependency_analysis(repo: RepoGraphData) -> dict[str, Node]:
     """Update repo based on a dependency analysis."""
     num_nodes = repo.graph.number_of_nodes()
-    logger.debug(f"a: {num_nodes}")
+    logger.debug("dependency_analysis: num_nodes=%d", num_nodes)
     node_probability = repo.df["node_probability_cache_hit"].to_dict()
     node_duration_s = repo.df["node_duration_s"].to_dict()
     group_probability = graph_algorithms.compute_group_probability(
         graph=repo.graph, node_probability=node_probability
     )
-    logger.debug(f"a: {repo.graph.number_of_edges()}")
+    logger.debug(
+        "dependency_analysis: num_edges=%d", repo.graph.number_of_edges()
+    )
     group_duration = graph_algorithms.compute_group_duration(
         graph=repo.graph, node_duration_s=node_duration_s
     )
-    logger.debug("a")
     pagerank = networkx.pagerank(repo.graph)
 
     # logger.debug(f"nodes: {len(graph.nodes)}")
@@ -267,7 +268,6 @@ def dependency_analysis(repo: RepoGraphData) -> dict[str, Node]:
     assert not isinstance(out_degree, int)
 
     reversed_graph = repo.graph.reverse()
-    logger.debug("a")
 
     # Compute depths
     forward_all_pairs_shortest_path_length = (
@@ -276,7 +276,6 @@ def dependency_analysis(repo: RepoGraphData) -> dict[str, Node]:
     reverse_all_pairs_shortest_path_length = (
         networkx.all_pairs_shortest_path_length(reversed_graph)
     )
-    logger.debug("a")
     descendant_depth: dict[str, int] = {}
     ancestor_depth: dict[str, int] = {}
     for node_name, pair_len_dict in tqdm.tqdm(
@@ -287,7 +286,6 @@ def dependency_analysis(repo: RepoGraphData) -> dict[str, Node]:
         reverse_all_pairs_shortest_path_length
     ):
         ancestor_depth[node_name] = max(pair_len_dict.values())
-    logger.debug("a")
 
     # Compute centrality metrics
     # k: number of pivot nodes for betweenness approximation. Floored at 1000
@@ -295,10 +293,8 @@ def dependency_analysis(repo: RepoGraphData) -> dict[str, Node]:
     # gives adequate relative rankings for top-N analysis without exact values.
     k = int(min(num_nodes, max(1_000, num_nodes**0.5)))
     betweenness = networkx.betweenness_centrality(repo.graph, k=k)
-    logger.debug("a")
     closeness = networkx.closeness_centrality(repo.graph)
 
-    logger.debug("a")
     nodes: dict[str, Node] = {}
     for node_name, cur_node in repo.df.iterrows():
         node_name = str(node_name)
@@ -338,5 +334,4 @@ def dependency_analysis(repo: RepoGraphData) -> dict[str, Node]:
             "closeness_centrality": closeness[node_name],
         }
         nodes[node_name] = row
-    logger.debug("a")
     return nodes


### PR DESCRIPTION
## Summary

Removes 7 `logger.debug("a")` placeholder calls left over from development in `dependency_analysis()` in `tlbox/apps/bazel_parser/repo_graph_data.py`. Two calls that had real data are kept but renamed from `"a: ..."` to proper `"dependency_analysis: ..."` format strings.

## Test plan

- [ ] Existing tests pass (`bazel test //tlbox/apps/bazel_parser/...`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5PXPYfmXXPA6B2jby1zKG)_