### PR TITLE
Filter python updates by our Python 3.11.9 constraint

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,10 @@
   "extends": ["config:recommended"],
   "prHourlyLimit": 10,
   "labels": ["dependencies"],
+  "constraints": {
+    "python": "3.11.9"
+  },
+  "constraintsFiltering": "strict",
   "vulnerabilityAlerts": {
     "groupName": "security updates",
     "postUpgradeTasks": {


### PR DESCRIPTION
## Summary
PR #400 ("Update python dependencies") kept failing its `postUpgradeTasks` because Renovate proposed `numpy==2.5.1`, which requires Python >=3.12. Our repo pins Python `3.11.9` (`MODULE.bazel`'s `PYTHON_VERSION`). Confirmed via the actual bazel error output (not the truncated PR comment): `Ignored the following versions that require a different python version: ... 2.5.1 Requires-Python >=3.12`. Initially suspected a transient PyPI propagation issue - it's not; it's a real, permanent incompatibility Renovate had no way to know about.

`constraintsFiltering` defaults to `"none"`, so Renovate doesn't filter candidate package versions by Python compatibility unless both `constraints.python` and `constraintsFiltering: "strict"` are set.

## Test plan
- [ ] Force-retry the `python-dependencies` branch (via Dependency Dashboard checkbox) after merging and confirm it no longer proposes `numpy==2.5.1`