### PR TITLE
Cap grpc below 1.76.0 to fix bazel-modules artifact failure

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,6 +41,11 @@
       "allowedVersions": "<0.71.0"
     },
     {
+      "matchManagers": ["bazel-module"],
+      "matchPackageNames": ["grpc"],
+      "allowedVersions": "<1.76.0"
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "github actions"
     }


### PR DESCRIPTION
## Summary
Fixes PR #395's persistent `bazel mod deps` artifact failure. Root cause and full evidence in #414.

Bisected locally: applied all of #395's other ~26 bumps while holding `grpc` back, `bazel mod deps` succeeded cleanly. Then bumped *only* `grpc` (1.74.1 -> 1.83.0) on top of otherwise-unmodified `MODULE.bazel` and reproduced the exact same error - confirms `grpc` alone is both necessary and sufficient.

Capped via `allowedVersions: "<1.76.0"`, matching where grpc's own BCR `MODULE.bazel` entries first freeze their `googleapis` dependency while continuing to bump `envoy_api` underneath it (see #414 for the version-by-version evidence).

## Test plan
- [ ] Merge, then force-retry the `bazel-modules` branch and confirm it no longer proposes `grpc` and `bazel mod deps` succeeds