### PR TITLE
Cap panel below 1.9.0 to avoid circular dependency with panel-material-ui

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,6 +46,11 @@
       "allowedVersions": "<1.76.0"
     },
     {
+      "matchManagers": ["pip_requirements"],
+      "matchPackageNames": ["panel"],
+      "allowedVersions": "<1.9.0"
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "github actions"
     }


### PR DESCRIPTION
## Summary
Fixes PR #400's persistent `bazel run //:gazelle_python_manifest.update` failure. Full diagnosis in #419.

`panel>=1.9.0` unconditionally requires `panel-material-ui>=0.10.0`, which in turn requires `panel>=1.8.0` back - confirmed directly against both packages' PyPI metadata. A genuine A->B->A circular dependency, not a resolution/timing artifact like the numpy or mypy cases earlier this week - Bazel's dependency graph is a strict DAG and can never represent this, so it won't resolve itself on a later run.

Capped via `allowedVersions: "<1.9.0"` - `1.8.10` (current pin) has no `panel-material-ui` dependency at all; the cycle starts exactly at `1.9.0`.

## Test plan
- [ ] Merge, then force-retry the `python-dependencies` branch and confirm it no longer proposes `panel>=1.9.0` and `gazelle_python_manifest.update` succeeds