### PR TITLE
Keep Renovate's Python toolchain updates in sync with rules_python

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,20 @@
     "python": "3.11.9"
   },
   "constraintsFiltering": "strict",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^MODULE\\.bazel$/", "/^tools/BUILD$/"],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "PYTHON_VERSION = \"(?<currentValue>3\\.\\d+\\.\\d+)\"",
+        "python_version = \"(?<currentValue>3\\.\\d+\\.\\d+)\","
+      ],
+      "depNameTemplate": "python",
+      "datasourceTemplate": "python-version",
+      "versioningTemplate": "python"
+    }
+  ],
   "vulnerabilityAlerts": {
     "groupName": "security updates",
     "postUpgradeTasks": {
@@ -53,6 +67,17 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "github actions"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["python"],
+      "groupName": "python toolchain version",
+      "commitMessageTopic": "Python toolchain version (MODULE.bazel / tools/BUILD)",
+      "allowedVersions": "/^(3\\.8\\.20|3\\.9\\.10|3\\.9\\.12|3\\.9\\.13|3\\.9\\.15|3\\.9\\.16|3\\.9\\.17|3\\.9\\.18|3\\.9\\.19|3\\.9\\.20|3\\.9\\.21|3\\.9\\.23|3\\.9\\.24|3\\.10\\.2|3\\.10\\.4|3\\.10\\.6|3\\.10\\.8|3\\.10\\.9|3\\.10\\.11|3\\.10\\.12|3\\.10\\.13|3\\.10\\.14|3\\.10\\.15|3\\.10\\.16|3\\.10\\.18|3\\.10\\.19|3\\.11\\.1|3\\.11\\.3|3\\.11\\.4|3\\.11\\.5|3\\.11\\.6|3\\.11\\.7|3\\.11\\.8|3\\.11\\.9|3\\.11\\.10|3\\.11\\.13|3\\.11\\.14|3\\.12\\.0|3\\.12\\.1|3\\.12\\.2|3\\.12\\.3|3\\.12\\.4|3\\.12\\.7|3\\.12\\.8|3\\.12\\.9|3\\.12\\.11|3\\.12\\.12|3\\.13\\.0|3\\.13\\.1|3\\.13\\.2|3\\.13\\.4|3\\.13\\.6|3\\.13\\.9|3\\.14\\.0)$/"
+    },
+    {
+      "matchDepTypes": ["tool-constraint"],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,6 +60,17 @@
       "allowedVersions": "<1.76.0"
     },
     {
+      "matchManagers": ["bazel-module"],
+      "matchPackageNames": ["rules_python"],
+      "postUpgradeTasks": {
+        "commands": [
+          "bazel run //tools/renovate:sync_python_toolchain_versions"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [".github/renovate.json"]
+      }
+    },
+    {
       "matchManagers": ["pip_requirements"],
       "matchPackageNames": ["panel"],
       "allowedVersions": "<1.9.0"

--- a/packaging/generated.bzl
+++ b/packaging/generated.bzl
@@ -85,5 +85,6 @@ PYTHON_TARGETS = [
     "//tools/black:black",
     "//tools/flake8:flake8",
     "//tools/isort:isort",
+    "//tools/renovate:sync_python_toolchain_versions",
     "//tools/sphinx:sphinx_build_wrapper",
 ]

--- a/tools/renovate/BUILD
+++ b/tools/renovate/BUILD
@@ -1,0 +1,7 @@
+load("//bzl:py.bzl", "py_binary")
+
+py_binary(
+    name = "sync_python_toolchain_versions",
+    srcs = ["sync_python_toolchain_versions.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/renovate/BUILD
+++ b/tools/renovate/BUILD
@@ -5,3 +5,5 @@ py_binary(
     srcs = ["sync_python_toolchain_versions.py"],
     visibility = ["//:__subpackages__"],
 )
+
+package(default_visibility = ["//visibility:private"])

--- a/tools/renovate/sync_python_toolchain_versions.py
+++ b/tools/renovate/sync_python_toolchain_versions.py
@@ -1,0 +1,86 @@
+"""Refreshes the Python "allowedVersions" allow-list in renovate.json.
+
+Reads the rules_python version pinned in MODULE.bazel, fetches that
+release's python/versions.bzl from GitHub, and rewrites the
+allowedVersions regex for the "python toolchain version" packageRule so
+Renovate only ever proposes bumping MODULE.bazel / tools/BUILD to a
+Python version rules_python actually has a prebuilt toolchain for.
+"""
+
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_BAZEL = REPO_ROOT / "MODULE.bazel"
+RENOVATE_JSON = REPO_ROOT / ".github/renovate.json"
+
+VERSIONS_BZL_URL = (
+    "https://raw.githubusercontent.com/bazelbuild/rules_python/"
+    "{version}/python/versions.bzl"
+)
+
+
+def pinned_rules_python_version() -> str:
+    match = re.search(
+        r'bazel_dep\(name = "rules_python", version = "([^"]+)"\)',
+        MODULE_BAZEL.read_text(),
+    )
+    if not match:
+        sys.exit("could not find rules_python bazel_dep in MODULE.bazel")
+    return match.group(1)
+
+
+def available_python_versions(rules_python_version: str) -> list[str]:
+    url = VERSIONS_BZL_URL.format(version=rules_python_version)
+    with urllib.request.urlopen(url) as response:
+        text = response.read().decode()
+    # TOOL_VERSIONS keys, e.g. `    "3.12.8": {`. Skip pre-releases
+    # (e.g. "3.15.0a1") since those aren't valid pins.
+    versions = re.findall(r'^ {4}"(\d+\.\d+\.\d+)":\s*\{', text, re.MULTILINE)
+    return sorted(set(versions), key=lambda v: tuple(map(int, v.split("."))))
+
+
+def render_allowed_versions(versions: list[str]) -> str:
+    escaped = "|".join(re.escape(version) for version in versions)
+    regex = f"/^({escaped})$/"
+    # Double backslashes so the regex survives as a JSON string literal.
+    return regex.replace("\\", "\\\\")
+
+
+def update_renovate_json(allowed_versions: str) -> None:
+    text = RENOVATE_JSON.read_text()
+    pattern = re.compile(
+        r'("groupName": "python toolchain version".*?"allowedVersions": ")'
+        r'[^"]*(")',
+        re.DOTALL,
+    )
+    new_text, count = pattern.subn(
+        lambda m: m.group(1) + allowed_versions + m.group(2), text
+    )
+    if count != 1:
+        sys.exit(
+            "expected exactly one 'python toolchain version' packageRule "
+            f"with an allowedVersions field, found {count}"
+        )
+    RENOVATE_JSON.write_text(new_text)
+
+
+def main() -> None:
+    rules_python_version = pinned_rules_python_version()
+    versions = available_python_versions(rules_python_version)
+    if not versions:
+        sys.exit(
+            f"no Python toolchain versions found for rules_python "
+            f"{rules_python_version}"
+        )
+    update_renovate_json(render_allowed_versions(versions))
+    print(
+        f"rules_python {rules_python_version}: {len(versions)} toolchain "
+        f"versions available, updated allowedVersions in {RENOVATE_JSON}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a `customManagers` regex entry so Renovate tracks `PYTHON_VERSION` in `MODULE.bazel` and `python_version` in `tools/BUILD` as a single dependency (datasource `python-version`), keeping the two in sync in one PR instead of drifting apart.
- Add `tools/renovate/sync_python_toolchain_versions.py`: reads the pinned `rules_python` version, fetches that release's `python/versions.bzl`, and rewrites the `allowedVersions` allow-list on the new "python toolchain version" packageRule to exactly the CPython patches rules_python has a prebuilt toolchain for (currently 3.8.20-3.14.0, 54 versions). Wired as a `postUpgradeTask` on the `rules_python` bazel-module rule so the allow-list re-derives itself whenever `rules_python` gets bumped.
- Disable the `tool-constraint` depType so Renovate stops proposing PRs to bump `constraints.python` in this file — that value only pins the Python version inside Renovate's own containerbase execution sandbox, not this repo's toolchain, and pinning it doesn't stop Renovate from treating it as an upgradeable dependency in its own right.

## Test plan
- [x] `bazel build //tools/renovate:sync_python_toolchain_versions` (passes, mypy clean)
- [x] `python3 -m json.tool .github/renovate.json` (valid JSON)
- [ ] Confirm next Renovate run stops opening `tool-constraint` PRs
- [ ] Confirm next `rules_python` bump PR includes an updated `allowedVersions` list via the postUpgradeTask

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLVCBPU3EGBbpxf4HP8sbN