### PR TITLE
Temporarily enable debug logging on the renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,6 +41,11 @@ jobs:
         # out to `bazel`.
         run: npx --yes renovate@43.278.5
         env:
+          # TODO(#424): temporary, to catch postUpgradeTasks silently not
+          # running for single-item vulnerabilityAlerts groups
+          # (#393/#394/#422). Remove once we've captured a debug log
+          # showing why.
+          LOG_LEVEL: debug
           RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary
`postUpgradeTasks` appears to silently not run for single-item `vulnerabilityAlerts` groups - confirmed (not just inferred) via `gazelle_python_manifest`'s Gazelle plugin source: `calculateIntegrity()` hashes the raw bytes of `requirements_lock.txt` directly, so its `integrity:` field in `gazelle_python.yaml` is mathematically guaranteed to change if the lock file changed at all. `#393`, `#394`, and `#422` all show the lock file changing with the manifest never moving; `#387` (many packages in one branch) didn't have this problem.

No exact matching upstream Renovate issue found (related but not identical: [renovatebot/renovate#7729](https://github.com/renovatebot/renovate/issues/7729), [discussion #42704](https://github.com/renovatebot/renovate/discussions/42704) - both about `postUpgradeTasks`/`executionMode: branch` being fragile, not this specific symptom).

Enables `LOG_LEVEL: debug` temporarily to actually see what Renovate logs internally when this happens, rather than keep guessing. Tracked for removal in #424 once we've captured it.

## Test plan
- [ ] Dispatch and force-retry a single-item security branch via the dashboard, then pull the debug log for that branch's processing