### PR TITLE
Prevent invalid pydantic-core/docutils bumps in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,6 +46,22 @@
       }
     },
     {
+      "matchManagers": ["pip_requirements"],
+      "matchPackageNames": ["pydantic-core"],
+      "description": [
+        "pydantic-core is always exact-pinned by whichever pydantic release is installed (see pydantic's own `Requires-Dist: pydantic-core==...`), so a standalone bump here is never valid on its own - hashin patches it directly without checking that pin, producing an inconsistent lockfile our full recompile then reverts (see #424 investigation, PR #426). It should only ever move as a side effect of a pydantic bump, which the full recompile resolves correctly - so disable it permanently rather than capping a version."
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["pip_requirements"],
+      "matchPackageNames": ["docutils"],
+      "description": [
+        "Capped below 0.23: sphinx==9.0.4 and myst-parser==5.1.0 both require docutils>=0.20,<0.23, and sphinx-rtd-theme==3.1.0 requires docutils<0.23,>0.18 (checked against locally fetched wheel METADATA). Same failure mode as pydantic-core - hashin bumped past this ceiling without checking sibling pins (PR #426). Revisit once those packages adopt a newer docutils."
+      ],
+      "allowedVersions": "<0.23"
+    },
+    {
       "matchManagers": ["bazel-module"],
       "groupName": "bazel modules"
     },


### PR DESCRIPTION
## Summary
- Disables standalone `pydantic-core` updates - it's always exact-pinned by whichever `pydantic` release is installed (`Requires-Dist: pydantic-core==...`), so a standalone bump is never valid; it should only ride along with a `pydantic` bump.
- Caps `docutils` to `<0.23` - `sphinx==9.0.4` and `myst-parser==5.1.0` require `docutils>=0.20,<0.23`, and `sphinx-rtd-theme==3.1.0` requires `docutils<0.23,>0.18` (checked against locally fetched wheel `METADATA`).

## Why
`hashin` (Renovate's native pip artifact updater) patches a single named package's version+hash directly, without checking sibling packages' exact pins. Our `postUpgradeTasks` full recompile (`bazel run //:requirements.update`) correctly detects the resulting invalid lockfile and reverts it on disk - but Renovate's commit is built from `hashin`'s in-memory edit regardless of what postUpgradeTasks found, so the PR ships the broken pins anyway with a stale gazelle manifest. This is what happened in #426 (closed): both `//:requirements_test` and `//:gazelle_python_manifest.test` failed in CI, and manually running the postUpgradeTasks commands on that branch produced a diff byte-identical to `master` - i.e. nothing valid to land.

## Test plan
- [x] `.github/renovate.json` validated as syntactically valid JSON
- [ ] Confirm next scheduled Renovate run no longer proposes these packages standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aa9aoUzUfgQcSPcq2oWGi