### PR TITLE
Re-enable bzlmod lockfile check, fix worktree pollution in lint.sh

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -9,3 +9,5 @@ node_modules
 bazel-bin
 bazel-out
 bazel-testlogs
+# Claude Code worktrees (separate checkouts, shouldn't be part of //...)
+.claude/worktrees

--- a/lint.sh
+++ b/lint.sh
@@ -61,25 +61,27 @@ done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
 
-# Find all Bazel-ish files - these templates come from Buildifier's default search list
-BAZEL_FILES=$(find ${REPO_ROOT} -type f \
-            \(   -name "*.bzl" \
-              -o -name "*.sky" \
-              -o -name "BUILD.bazel" \
-              -o -name "BUILD" \
-              -o -name "*.BUILD" \
-              -o -name "BUILD.*.bazel" \
-              -o -name "BUILD.*.oss" \
-              -o -name "MODULE.bazel" \
-              -o -name "WORKSPACE" \
-              -o -name "WORKSPACE.bazel" \
-              -o -name "WORKSPACE.oss" \
-              -o -name "WORKSPACE.*.bazel" \
-              -o -name "WORKSPACE.*.oss" \) \
-              -print)
+# Find all git-tracked Bazel-ish files - these templates come from Buildifier's
+# default search list. Literal (non-glob) names need both the bare and "**/"
+# forms since git pathspec only matches wildcard patterns at any depth.
+BAZEL_FILES=$(git -C "${REPO_ROOT}" ls-files -- \
+              '*.bzl' \
+              '*.sky' \
+              'BUILD.bazel' '**/BUILD.bazel' \
+              'BUILD' '**/BUILD' \
+              '*.BUILD' \
+              'BUILD.*.bazel' \
+              'BUILD.*.oss' \
+              'MODULE.bazel' '**/MODULE.bazel' \
+              'WORKSPACE' '**/WORKSPACE' \
+              'WORKSPACE.bazel' '**/WORKSPACE.bazel' \
+              'WORKSPACE.oss' '**/WORKSPACE.oss' \
+              'WORKSPACE.*.bazel' \
+              'WORKSPACE.*.oss' \
+            | sed "s|^|${REPO_ROOT}/|")
 
-# Find all Markdown-ish files
-MARKDOWN_FILES=$(find ${REPO_ROOT} -type f -name "*.md" -print)
+# Find all git-tracked Markdown-ish files
+MARKDOWN_FILES=$(git -C "${REPO_ROOT}" ls-files -- '*.md' | sed "s|^|${REPO_ROOT}/|")
 
 # Check if the flag was set
 if [ -z "$mode" ]; then
@@ -132,10 +134,8 @@ grep_xxx
 # --aspects=//tools/lint:linters.bzl%clang_tidy
 
 
-# TODO(#57): Re-enable this check when we fix the false errors
-# - name: bzlmod lockfile
-#   run: |
-#     bazel mod deps --lockfile_mode=error
+# Verify MODULE.bazel.lock is up to date (fixed by rules_rust upgrade, #57, #392)
+bazel mod deps --lockfile_mode=error
 
 
 printf "\n✨ Linting completed successfully! ✨\n"

--- a/tools/renovate/BUILD
+++ b/tools/renovate/BUILD
@@ -1,9 +1,9 @@
 load("//bzl:py.bzl", "py_binary")
 
+package(default_visibility = ["//visibility:private"])
+
 py_binary(
     name = "sync_python_toolchain_versions",
     srcs = ["sync_python_toolchain_versions.py"],
     visibility = ["//:__subpackages__"],
 )
-
-package(default_visibility = ["//visibility:private"])


### PR DESCRIPTION
## Summary
- Re-enable `bazel mod deps --lockfile_mode=error` in `lint.sh` — it was disabled in #57 due to a rules_rust bug that's since been fixed by the 0.45.1→0.70.0 upgrade in #392, so `MODULE.bazel.lock` drift can be caught in CI again.
- Switch `lint.sh`'s Bazel/Markdown file discovery from `find` to `git ls-files`, and exclude `.claude/worktrees` in `.bazelignore` — both `find` and `bazel query //...` were picking up stale checkouts under `.claude/worktrees/`, causing spurious buildifier/gazelle errors unrelated to the actual repo content.
- Incidental `tools/renovate/BUILD` gazelle reorder picked up while re-running `./lint.sh --mode format`.

## Test plan
- [x] `./lint.sh --mode check` passes end-to-end, including the re-enabled lockfile check
- [x] `./lint.sh --mode format` runs clean with no unexpected diffs
- [x] `bazel mod deps --lockfile_mode=error` verified standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKNoA1cFA5GVWv4aj3dmj2