### PR TITLE
Rename our pip bzlmod hub from "pip" to "toolbox_pip"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,11 +4,11 @@
 # ruleset. When the symbol is loaded you can use the rule.
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@pip//:requirements.bzl", "all_whl_requirements")
 load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
 load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
 load("@rules_uv//uv:pip.bzl", "pip_compile")
 load("@rules_uv//uv:venv.bzl", "create_venv")
+load("@toolbox_pip//:requirements.bzl", "all_whl_requirements")
 load("//:copts_transition.bzl", "executable_with_copts")
 
 package(default_visibility = ["//visibility:private"])
@@ -75,7 +75,7 @@ modules_mapping(
 gazelle_python_manifest(
     name = "gazelle_python_manifest",
     modules_mapping = ":modules_map",
-    pip_repository_name = "pip",
+    pip_repository_name = "toolbox_pip",
     # NOTE: We can pass a list just like in `bzlmod_build_file_generation` example
     # but we keep a single target here for regression testing.
     requirements = "//:requirements_lock.txt",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -365,9 +365,9 @@ use_repo(multitool, "multitool")
 types = use_extension("@rules_mypy//mypy:types.bzl", "types")
 types.requirements(
     name = "pip_types",
-    # `@pip` in the next line corresponds to the `hub_name` when using
-    # rules_python's `pip.parse(...)`.
-    pip_requirements = "@pip//:requirements.bzl",
+    # `@toolbox_pip` in the next line corresponds to the `hub_name` when
+    # using rules_python's `pip.parse(...)`.
+    pip_requirements = "@toolbox_pip//:requirements.bzl",
     # also legal to pass a `requirements.in` here
     requirements_txt = "//:requirements_lock.txt",
 )
@@ -466,6 +466,11 @@ python.single_version_platform_override(
 )
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+# NOTE: hub_name is "toolbox_pip" rather than the more obvious "pip" because
+# pip hub names must be unique across the whole module graph, and some
+# dependencies (e.g. newer emboss releases) declare their own "pip" hub --
+# see #402.
 pip.parse(
     # TODO(#209)
     # Avoid building wheels with system compiler
@@ -500,7 +505,7 @@ pip.parse(
             "panel-material-ui",
         ],
     },
-    hub_name = "pip",
+    hub_name = "toolbox_pip",
     python_version = PYTHON_VERSION,
     requirements_lock = "//:requirements_lock.txt",
 )
@@ -511,7 +516,7 @@ pip.parse(
 # --python-version
 # --implementation
 # --abi
-use_repo(pip, "pip")
+use_repo(pip, "toolbox_pip")
 
 #############
 # rules_rust

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1659,15 +1659,15 @@
     "@@rules_mypy+//mypy:types.bzl%types": {
       "general": {
         "bzlTransitiveDigest": "NRCQLKlh6DMNV8O7wtrrgFwoxCrepDJ64vJWgl4xKIo=",
-        "usagesDigest": "VQtlosoIEjw4qRsLJc07jRq+h07EMDe4XfWbwNlOQrE=",
+        "usagesDigest": "wewhQJ9zu0o2pLoIXr3E/b2PanMKJ7+yyNH56fmlw58=",
         "recordedInputs": [
-          "REPO_MAPPING:,pip rules_python++pip+pip"
+          "REPO_MAPPING:,toolbox_pip rules_python++pip+toolbox_pip"
         ],
         "generatedRepoSpecs": {
           "pip_types": {
             "repoRuleId": "@@rules_mypy+//mypy/private:types.bzl%generate",
             "attributes": {
-              "pip_requirements": "@@rules_python++pip+pip//:requirements.bzl",
+              "pip_requirements": "@@rules_python++pip+toolbox_pip//:requirements.bzl",
               "requirements_txt": "@@//:requirements_lock.txt",
               "exclude_requirements": []
             }

--- a/apps/rubiks/BUILD
+++ b/apps/rubiks/BUILD
@@ -6,5 +6,5 @@ py_binary(
     name = "rubiks",
     srcs = ["rubiks.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//numpy"],
+    deps = ["@toolbox_pip//numpy"],
 )

--- a/bzl/BUILD
+++ b/bzl/BUILD
@@ -11,7 +11,7 @@ py_binary(
     name = "pytest_main",
     srcs = ["pytest_main.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//pytest"],
+    deps = ["@toolbox_pip//pytest"],
 )
 
 sh_binary(

--- a/bzl/py.bzl
+++ b/bzl/py.bzl
@@ -21,7 +21,7 @@ def py_library(**kwargs):
 
 def py_test(srcs, deps = [], args = [], data = [], timeout = "short", **kwargs):
     deps = deps + [
-        "@pip//pytest",
+        "@toolbox_pip//pytest",
     ]
     unique_deps = {d: None for d in deps}
 

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -49,5 +49,5 @@ py_library(
     srcs = ["conf.py"],
     tags = ["no-mypy"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//sphinx_rtd_theme"],
+    deps = ["@toolbox_pip//sphinx_rtd_theme"],
 )

--- a/examples/basic/BUILD
+++ b/examples/basic/BUILD
@@ -107,7 +107,7 @@ py_binary(
     deps = [
         "//examples/basic:hello_grpc_py_library",
         "//examples/basic:hello_py_library",
-        "@pip//grpcio",
+        "@toolbox_pip//grpcio",
     ],
 )
 
@@ -127,7 +127,7 @@ py_binary(
     deps = [
         "//examples/basic:hello_grpc_py_library",
         "//examples/basic:hello_py_library",
-        "@pip//grpcio",
+        "@toolbox_pip//grpcio",
     ],
 )
 

--- a/examples/simpy/BUILD
+++ b/examples/simpy/BUILD
@@ -6,12 +6,12 @@ py_binary(
     name = "car_tutorial",
     srcs = ["car_tutorial.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//simpy"],
+    deps = ["@toolbox_pip//simpy"],
 )
 
 py_binary(
     name = "thermostat_example",
     srcs = ["thermostat_example.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//simpy"],
+    deps = ["@toolbox_pip//simpy"],
 )

--- a/examples/tofupilot/BUILD
+++ b/examples/tofupilot/BUILD
@@ -7,7 +7,7 @@ py_binary(
     srcs = ["tofupilot_example.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pip//openhtf",
-        "@pip//tofupilot",
+        "@toolbox_pip//openhtf",
+        "@toolbox_pip//tofupilot",
     ],
 )

--- a/examples/vpython/BUILD
+++ b/examples/vpython/BUILD
@@ -16,7 +16,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":pkg_resources",
-        "@pip//vpython",
+        "@toolbox_pip//vpython",
     ],
 )
 
@@ -40,6 +40,6 @@ py_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         "//examples/vpython:vpython_stub",
-        "@pip//numpy",
+        "@toolbox_pip//numpy",
     ],
 )

--- a/gazelle_python.yaml
+++ b/gazelle_python.yaml
@@ -362,5 +362,5 @@ manifest:
     zmq: pyzmq
     zstandard: zstandard
   pip_repository:
-    name: pip
-integrity: 56844c3c4aecdcd342bc9429ee229af403f925f70615d50226a2d034521fde61
+    name: toolbox_pip
+integrity: 2b22763730f0bf59ca4b6f5f9a7abdd915adb902ca327af42e5e3847d31ba24b

--- a/third_party/delimited_protobuf/delimited_protobuf.py
+++ b/third_party/delimited_protobuf/delimited_protobuf.py
@@ -28,7 +28,7 @@ from google.protobuf import message
 from google.protobuf.internal import decoder
 from google.protobuf.internal import encoder
 
-# Gazelle pulls this in as @pip//protobuf instead of
+# Gazelle pulls this in as @toolbox_pip//protobuf instead of
 # @com_google_protobuf//:protobuf_python, which causes a type-hinting issue
 # gazelle:ignore google.protobuf.internal
 

--- a/tlbox/apps/bazel_parser/BUILD
+++ b/tlbox/apps/bazel_parser/BUILD
@@ -18,9 +18,9 @@ py_library(
     ],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pip//bokeh",
-        "@pip//networkx",
-        "@pip//panel",
+        "@toolbox_pip//bokeh",
+        "@toolbox_pip//networkx",
+        "@toolbox_pip//panel",
     ],
 )
 
@@ -30,8 +30,8 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         ":repo_graph_data",
-        "@pip//numpy",
-        "@pip//pandas",
+        "@toolbox_pip//numpy",
+        "@toolbox_pip//pandas",
     ],
 )
 
@@ -41,9 +41,9 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//tlbox/utils:graph_algorithms",
-        "@pip//networkx",
-        "@pip//pandas",
-        "@pip//tqdm",
+        "@toolbox_pip//networkx",
+        "@toolbox_pip//pandas",
+        "@toolbox_pip//tqdm",
     ],
 )
 
@@ -52,7 +52,7 @@ py_test(
     srcs = ["repo_graph_data_test.py"],
     deps = [
         ":repo_graph_data",
-        "@pip//networkx",
+        "@toolbox_pip//networkx",
     ],
 )
 
@@ -64,7 +64,7 @@ py_library(
         ":repo_graph_data",
         "//third_party/bazel/src/main/protobuf:build_py_library",
         "//tlbox/utils:git_utils",
-        "@pip//networkx",
+        "@toolbox_pip//networkx",
     ],
 )
 
@@ -80,10 +80,10 @@ py_binary(
         "//tlbox/utils:bep_reader",
         "//tlbox/utils:git_utils",
         "//tools:git_py_library",
-        "@pip//click",
-        "@pip//networkx",
-        "@pip//pandas",
-        "@pip//pydantic",
-        "@pip//pyyaml",
+        "@toolbox_pip//click",
+        "@toolbox_pip//networkx",
+        "@toolbox_pip//pandas",
+        "@toolbox_pip//pydantic",
+        "@toolbox_pip//pyyaml",
     ],
 )

--- a/tlbox/apps/code_metrics/BUILD
+++ b/tlbox/apps/code_metrics/BUILD
@@ -10,10 +10,10 @@ py_binary(
         ":models",
         "//tlbox/utils:bazel_utils",
         "//tlbox/utils:git_utils",
-        "@pip//click",
-        "@pip//psycopg2_binary",
-        "@pip//sqlalchemy",
-        "@pip//tabulate",
+        "@toolbox_pip//click",
+        "@toolbox_pip//psycopg2_binary",
+        "@toolbox_pip//sqlalchemy",
+        "@toolbox_pip//tabulate",
     ],
 )
 
@@ -22,7 +22,7 @@ py_binary(
     srcs = ["models.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pip//psycopg2_binary",
-        "@pip//sqlalchemy",
+        "@toolbox_pip//psycopg2_binary",
+        "@toolbox_pip//sqlalchemy",
     ],
 )

--- a/tlbox/apps/csv-to-sheets/BUILD
+++ b/tlbox/apps/csv-to-sheets/BUILD
@@ -7,7 +7,7 @@ py_binary(
     srcs = ["csv2sheets.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pip//gspread",
-        "@pip//oauth2client",
+        "@toolbox_pip//gspread",
+        "@toolbox_pip//oauth2client",
     ],
 )

--- a/tlbox/apps/gmail_analysis/BUILD
+++ b/tlbox/apps/gmail_analysis/BUILD
@@ -7,10 +7,10 @@ py_binary(
     srcs = ["gmail_analysis.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pip//google_api_python_client",
-        "@pip//google_auth",
-        "@pip//google_auth_oauthlib",
-        "@pip//matplotlib",
-        "@pip//pandas",
+        "@toolbox_pip//google_api_python_client",
+        "@toolbox_pip//google_auth",
+        "@toolbox_pip//google_auth_oauthlib",
+        "@toolbox_pip//matplotlib",
+        "@toolbox_pip//pandas",
     ],
 )

--- a/tlbox/apps/ical/BUILD
+++ b/tlbox/apps/ical/BUILD
@@ -6,5 +6,5 @@ py_binary(
     name = "read_ical_rrules",
     srcs = ["read_ical_rrules.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//icalendar"],
+    deps = ["@toolbox_pip//icalendar"],
 )

--- a/tlbox/scripts/parsing_scripts/BUILD
+++ b/tlbox/scripts/parsing_scripts/BUILD
@@ -6,7 +6,7 @@ py_binary(
     name = "pocket_export_html_to_csv",
     srcs = ["pocket_export_html_to_csv.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//beautifulsoup4"],
+    deps = ["@toolbox_pip//beautifulsoup4"],
 )
 
 py_binary(

--- a/tlbox/utils/BUILD
+++ b/tlbox/utils/BUILD
@@ -7,8 +7,8 @@ py_library(
     srcs = ["graph_algorithms.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pip//networkx",
-        "@pip//tqdm",
+        "@toolbox_pip//networkx",
+        "@toolbox_pip//tqdm",
     ],
 )
 
@@ -17,7 +17,7 @@ py_test(
     srcs = ["graph_algorithms_test.py"],
     deps = [
         ":graph_algorithms",
-        "@pip//networkx",
+        "@toolbox_pip//networkx",
     ],
 )
 
@@ -29,8 +29,8 @@ py_binary(
         "//third_party/bazel/proto:build_event_stream_py_library",
         "//third_party/bazel/proto:spawn_py_library",
         "//third_party/delimited_protobuf",
-        "@pip//tabulate",
-        "@pip//zstandard",
+        "@toolbox_pip//tabulate",
+        "@toolbox_pip//zstandard",
     ],
 )
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -3,9 +3,9 @@ load("@build_stack_rules_proto//rules:proto_compile.bzl", "proto_compile")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@multitool//:tools.bzl", MULTITOOL_TOOLS = "TOOLS")
-load("@pip//:requirements.bzl", "requirement")  # '@pip' must match configured pip hub_name
 load("@rules_multirun//:defs.bzl", "command", "multirun")
 load("@rules_mypy//mypy:mypy.bzl", "mypy_cli")
+load("@toolbox_pip//:requirements.bzl", "requirement")  # '@toolbox_pip' must match configured pip hub_name
 load("//bzl:py.bzl", "proto_py_library", "py_library")
 
 package(default_visibility = ["//visibility:private"])
@@ -109,7 +109,7 @@ mypy_cli(
     # LINK(7e463bc3_e4d9_4464_ba39_3217c4a86004)
     python_version = "3.12.12",
     deps = [
-        "@pip//types_protobuf",
+        "@toolbox_pip//types_protobuf",
     ],
 )
 

--- a/tools/black/BUILD
+++ b/tools/black/BUILD
@@ -9,6 +9,6 @@ py_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         "//tools:utils",
-        "@pip//black",
+        "@toolbox_pip//black",
     ],
 )

--- a/tools/flake8/BUILD
+++ b/tools/flake8/BUILD
@@ -12,6 +12,6 @@ py_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         "//tools:utils",
-        "@pip//flake8",
+        "@toolbox_pip//flake8",
     ],
 )

--- a/tools/isort/BUILD
+++ b/tools/isort/BUILD
@@ -9,6 +9,6 @@ py_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         "//tools:utils",
-        "@pip//isort",
+        "@toolbox_pip//isort",
     ],
 )

--- a/tools/sphinx/BUILD
+++ b/tools/sphinx/BUILD
@@ -8,19 +8,19 @@ py_binary(
     tags = ["no-mypy"],
     visibility = ["//visibility:public"],
     deps = [
-        "@pip//furo",  # keep
-        "@pip//linkify_it_py",  # keep
-        "@pip//myst_parser",  # keep
-        "@pip//sphinx",  # keep
-        "@pip//sphinx_autoapi",  # keep
-        "@pip//sphinx_copybutton",  # keep
-        "@pip//sphinx_design",  # keep
-        "@pip//sphinx_pyscript",  # keep
-        "@pip//sphinx_rtd_theme",  # keep
-        "@pip//sphinx_tippy",  # keep
-        "@pip//sphinx_togglebutton",  # keep
-        "@pip//sphinxcontrib_mermaid",  # keep
-        "@pip//sphinxext_opengraph",  # keep
-        "@pip//sphinxext_rediraffe",  # keep
+        "@toolbox_pip//furo",  # keep
+        "@toolbox_pip//linkify_it_py",  # keep
+        "@toolbox_pip//myst_parser",  # keep
+        "@toolbox_pip//sphinx",  # keep
+        "@toolbox_pip//sphinx_autoapi",  # keep
+        "@toolbox_pip//sphinx_copybutton",  # keep
+        "@toolbox_pip//sphinx_design",  # keep
+        "@toolbox_pip//sphinx_pyscript",  # keep
+        "@toolbox_pip//sphinx_rtd_theme",  # keep
+        "@toolbox_pip//sphinx_tippy",  # keep
+        "@toolbox_pip//sphinx_togglebutton",  # keep
+        "@toolbox_pip//sphinxcontrib_mermaid",  # keep
+        "@toolbox_pip//sphinxext_opengraph",  # keep
+        "@toolbox_pip//sphinxext_rediraffe",  # keep
     ],
 )


### PR DESCRIPTION
## Summary
- While digging into why Renovate's #402 (\"Update bazel modules (major)\") was failing, found that bumping `emboss` to `2026.0212.185041` breaks bzlmod resolution entirely: that emboss version declares its own `pip.parse(hub_name = "pip", ...)`, which collides with our own `pip` hub declared in the root `MODULE.bazel`:
  ```
  Error in fail: Duplicate cross-module pip hub named 'pip': pip hub names must be unique across modules. First defined by module 'mchristen', second attempted by module 'emboss'
  ```
- This is also why Renovate's own automatic lockfile regeneration (`bazelModDeps`, enabled via `RENOVATE_ALLOWED_UNSAFE_EXECUTIONS` in `renovate.yml`) was failing on that PR (`renovate/artifacts: Artifact file update failure`).
- Renamed our hub to `toolbox_pip` rather than capping emboss's version, since the collision is fundamentally about our hub using the generic, easily-collided-with name `"pip"` — this is a one-time fix rather than an ongoing version cap we'd need to maintain and eventually lift.
- Updated every `@pip//` reference across the repo (BUILD files, `.bzl`, `.py`), the `pip_repository_name` used by `gazelle_python_manifest`, and the `pip_requirements` label used by `rules_mypy`'s `types.requirements()`. Regenerated `gazelle_python.yaml` and `MODULE.bazel.lock`.

Once merged, Renovate should be able to rebase #402 cleanly on its next run.

## Test plan
- [x] `bazel build //...` — 287/287 targets
- [x] `bazel test //...` — 24/24 tests pass (including `gazelle_python_manifest.test`)
- [x] `./lint.sh --mode check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183bQrFTzZQE5HEnJnbrBcs