### PR TITLE
Add minimumReleaseAge soak period to Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,10 @@
     "python": "3.11.9"
   },
   "constraintsFiltering": "strict",
+  "dependencyDashboard": true,
+  "minimumReleaseAge": "3 days",
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "customManagers": [
     {
       "customType": "regex",
@@ -23,6 +27,7 @@
   ],
   "vulnerabilityAlerts": {
     "groupName": "security updates",
+    "minimumReleaseAge": null,
     "postUpgradeTasks": {
       "commands": [
         "bazel run //:requirements.update",


### PR DESCRIPTION
## Summary
- PR #435 hit a hash mismatch: `hashin` fetched incorrect sha256 digests for `prompt-toolkit` 3.0.53, which had been published on PyPI only hours earlier - most likely a transient PyPI JSON-metadata propagation issue for a same-day release. Bazel's own hash verification caught it downstream, but only after it had already broken the `gazelle_python_manifest.update` postUpgradeTask and Build and Test.
- Adds a global `minimumReleaseAge: "3 days"` so Renovate waits for releases to settle before proposing them, combined with `prCreation: "not-pending"` and `internalChecksFilter: "strict"` so branches/PRs aren't created at all until a non-pending version is available.
- `dependencyDashboard: true` surfaces the suppressed/waiting updates in the meantime.
- `vulnerabilityAlerts` explicitly overrides `minimumReleaseAge` back to `null` so security-fix PRs aren't delayed by the soak-time rule.

## Test plan
- [x] Validated against Renovate's own JSON schema (`docs.renovatebot.com/renovate-schema.json`) with zero errors
- [ ] Confirm next Renovate run (scheduled or `workflow_dispatch`) picks up the config without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dms9Yj2zRo6w1nAPqNWrri