### PR TITLE
Disable Renovate tracking of the pico-sdk git_override commit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,14 @@
     },
     {
       "matchManagers": ["bazel-module"],
+      "matchPackageNames": ["pico-sdk"],
+      "description": [
+        "pico-sdk is git_override'd to a specific, manually-vetted commit on a community fork (RyanDraves/pico-sdk#bazel-2.3.0-patch) that fixes BCR pico-sdk 2.3.0's broken Bazel packaging plus two more issues we found (see #395, #437). Renovate's bazel-module manager tracks git_override commits like any other dependency and will happily bump it to whatever the fork's branch tip is, which isn't validated and broke #395's rebase once. Disable tracking entirely; this override should only move via a manual, tested bump, and ideally gets removed once upstream/BCR ships a real fix."
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["bazel-module"],
       "matchPackageNames": ["rules_python"],
       "postUpgradeTasks": {
         "commands": [


### PR DESCRIPTION
## Summary
- Renovate's `bazel-module` manager treats `git_override` commits like any other trackable dependency, and bumped our manually-vetted `pico-sdk` pin (`RyanDraves/pico-sdk#bazel-2.3.0-patch` @ `ef9ddf9`, landed in #437) to whatever the fork branch's tip happened to be. That commit was never validated by us and broke #395's CI as soon as Renovate rebased it in.
- This override is a deliberate, tested pin — it should only move via a manual bump we've actually built and tested against, not an automated one silently tracking someone else's branch. Disabled Renovate tracking for `pico-sdk` entirely (matching the existing `rules_rust`/etc. pattern), with a description note on when/why to remove it (once upstream/BCR ships a real fix, per #395/#437).

## Test plan
- [x] `./lint.sh --mode check` passes (validates `renovate.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183bQrFTzZQE5HEnJnbrBcs