### PR TITLE
Use a PAT for Renovate so it can push workflow-file updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -46,7 +46,13 @@ jobs:
           # (#393/#394/#422). Remove once we've captured a debug log
           # showing why.
           LOG_LEVEL: debug
-          RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The auto-generated GITHUB_TOKEN can never create/update files
+          # under .github/workflows/ (GitHub blocks this unconditionally,
+          # regardless of granted permissions, to stop workflows from
+          # self-escalating). A fine-grained PAT with Contents/Workflows/PRs
+          # write is required so the github-actions manager's branches can
+          # actually be pushed - see #382.
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_GH_TOKEN }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # bazel-module manager needs this to run `bazel mod deps` and


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` is unconditionally blocked by GitHub from creating/updating files under `.github/workflows/`, regardless of granted permissions — this is why the `github-actions` Renovate manager silently never opened PRs (checking the dashboard box did nothing).
- Log evidence: the `renovate/github-actions` and `renovate/major-github-actions` branches were committed locally but the push failed with `refusing to allow a GitHub App to create or update workflow ... without workflows permission` (run https://github.com/michael-christen/toolbox/actions/runs/30332332055/job/90189962292).
- Switches `RENOVATE_TOKEN` to read from a new `RENOVATE_GH_TOKEN` secret instead of `secrets.GITHUB_TOKEN`.

Fixes #382 (github-actions update branches).

## Test plan
- [ ] Add a fine-grained PAT (Contents/Workflows/Pull requests: write, scoped to this repo) as the `RENOVATE_GH_TOKEN` repo secret before merging
- [ ] Re-run the Renovate workflow via `workflow_dispatch` after merge
- [ ] Confirm `renovate/github-actions` and `renovate/major-github-actions` PRs get created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dms9Yj2zRo6w1nAPqNWrri