### PR TITLE
Force Renovate to commit via the GitHub API for verified commits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
   "minimumReleaseAge": "3 days",
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
+  "platformCommit": "always",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- Since switching `RENOVATE_TOKEN` to a fine-grained PAT (#440), Renovate's `platformCommit: "auto"` default no longer recognizes an App-style token and falls back to local `git commit` + `git push` on the runner, which is never signed.
- Confirmed: pre-PAT commits (e.g. `54ba6e3` on the merged python-dependencies PR) show `verification.reason: "valid"`; post-PAT commits (e.g. `badfeb8e` on #443) show `verification.reason: "unsigned"`.
- `"platformCommit": "always"` forces Renovate to create commits through the GitHub Git Data API instead, which GitHub signs/verifies itself regardless of token type. No new PAT scope needed - it uses the `Contents: write` permission already granted.

## Test plan
- [x] After merge, close PRs #443/#444 and delete their branches so Renovate recreates them fresh under the new setting
- [ ] Confirm the recreated commits show as "Verified" on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dms9Yj2zRo6w1nAPqNWrri