### PR TITLE
Fix platformCommit value: "always" isn't real, "enabled" is

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
   "minimumReleaseAge": "3 days",
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
-  "platformCommit": "always",
+  "platformCommit": "enabled",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- #445 introduced `"platformCommit": "always"` to get verified/signed Renovate commits, but `"always"` isn't a real value - Renovate v43.278.5's schema only accepts `["auto", "disabled", "enabled"]` (`lib/config/options/index.ts`).
- Since `"always" !== "enabled"`, the GitHub-specific gate in `scm.ts` silently fell through to the local-git commit path every run (no validation error, no warning) - confirmed the recreated `renovate/github-actions`/`renovate/major-github-actions` commits were still `unsigned` after #445 merged.
- Switches the value to the real one: `"enabled"`.

Side note for context: `"auto"` (the default) only self-upgrades to API-based commits when Renovate detects it's running as a GitHub App - a PAT is never auto-detected that way, so `"enabled"` needs to be explicit for a PAT-authenticated setup like this one.

## Test plan
- [ ] After merge, close the current `renovate/github-actions`/`renovate/major-github-actions` PRs and delete their branches so Renovate recreates them
- [ ] Confirm the recreated commits show as "Verified" on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dms9Yj2zRo6w1nAPqNWrri