### PR TITLE
Revert Renovate to GITHUB_TOKEN, trading verified commits for automated github-actions PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,6 @@
   "minimumReleaseAge": "3 days",
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
-  "platformCommit": "enabled",
   "customManagers": [
     {
       "customType": "regex",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -46,13 +46,20 @@ jobs:
           # (#393/#394/#422). Remove once we've captured a debug log
           # showing why.
           LOG_LEVEL: debug
-          # The auto-generated GITHUB_TOKEN can never create/update files
-          # under .github/workflows/ (GitHub blocks this unconditionally,
-          # regardless of granted permissions, to stop workflows from
-          # self-escalating). A fine-grained PAT with Contents/Workflows/PRs
-          # write is required so the github-actions manager's branches can
-          # actually be pushed - see #382.
-          RENOVATE_TOKEN: ${{ secrets.RENOVATE_GH_TOKEN }}
+          # Reverted from a fine-grained PAT (#440/#445/#448) back to the
+          # default GITHUB_TOKEN. The PAT let the github-actions manager
+          # push branches touching .github/workflows/ (GITHUB_TOKEN is
+          # unconditionally blocked from writing those files, regardless of
+          # granted permissions - see #382), but it traded away something
+          # GITHUB_TOKEN gets for free: GitHub only auto-signs/verifies
+          # commits it authors on behalf of a GitHub App-like identity
+          # (which is what GITHUB_TOKEN presents as); a personal PAT commits
+          # as the human account and is never eligible for that signature,
+          # through the git-push path or Renovate's platformCommit API path
+          # alike. Verified commits won out over automated github-actions
+          # PRs - those now need to be opened/pushed manually when the
+          # dependency dashboard flags a pending github-actions update.
+          RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # bazel-module manager needs this to run `bazel mod deps` and


### PR DESCRIPTION
## Summary
- #440 switched Renovate's `RENOVATE_TOKEN` to a fine-grained PAT so the `github-actions` manager could push branches touching `.github/workflows/` (`GITHUB_TOKEN` is unconditionally blocked from writing those files, regardless of granted permissions - #382).
- That worked, but it broke commit verification. GitHub only auto-signs commits authored on behalf of a GitHub-App-like identity, which is what `GITHUB_TOKEN` presents as. A personal PAT commits as the human account instead, and nothing in Renovate's config changes that - not `platformCommit: "always"` (#445, not even a real value), not the corrected `"enabled"` (#448).
- Confirmed directly: even with `platformCommit: "enabled"` correctly forcing the API commit path, the resulting commit still had `committer: "Michael Christen <mchristen96@gmail.com>"`, not `"GitHub <noreply@github.com>"`, and stayed unsigned. GitHub's "Verified" badge is a GitHub Apps behavior, not a Renovate config knob.
- Verified commits matter more than automated `github-actions` PRs here, so this reverts `RENOVATE_TOKEN` to `secrets.GITHUB_TOKEN` and drops the now-inert `platformCommit` override (`GITHUB_TOKEN`'s App-like identity already gets `"auto"` to self-upgrade to API-based, verified commits with no extra config).

## Trade-off going forward
The `github-actions` manager's branches will fail to push again whenever they touch `.github/workflows/` (same failure as pre-#440: `refusing to allow a GitHub App to create or update workflow ... without workflows permission`). Going forward, github-actions updates flagged on the dependency dashboard need to be applied and PR'd manually.

## Test plan
- [ ] After merge, confirm the next Renovate run produces verified commits again for non-workflow-file branches (e.g. pip_requirements, bazel-module)
- [ ] Manually apply the still-pending github-actions bumps currently sitting in #446/#447/#449 (bazel-contrib/setup-bazel, codecov/codecov-action, actions/checkout v7, etc.), since Renovate can no longer push them itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dms9Yj2zRo6w1nAPqNWrri